### PR TITLE
Bump version for managed release installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kaist-cli"
-version = "0.1.4"
+version = "0.2.0"
 description = "CLI for KAIST systems (starting with KLMS)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/kaist_cli/__init__.py
+++ b/src/kaist_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.1.4"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ wheels = [
 
 [[package]]
 name = "kaist-cli"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary\n- bump the packaged CLI version to 0.2.0\n- align the managed release tag with the merged rewrite and installer\n\n## Testing\n- PYTHONPYCACHEPREFIX=/tmp/kaist-cli-pyc uv run --with pytest pytest -q\n- scripts/build_release_bundle.sh --binary /tmp/kaist-release-smoke/kaist --version v0.2.0 --target darwin-arm64 --out-dir /tmp/kaist-release-smoke\n- PYTHONPATH=src uv run python -m kaist_cli.main --agent version