### PR TITLE
Add SSO easy login and Intel macOS release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,16 @@ permissions:
   contents: write
 
 jobs:
-  build-darwin-arm64:
-    runs-on: macos-14
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            runner: macos-14
+          - target: darwin-x86_64
+            runner: macos-13
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,18 +52,39 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          TARGET="darwin-arm64"
           scripts/build_release_bundle.sh \
             --binary dist/kaist \
             --version "${TAG}" \
-            --target "${TARGET}" \
+            --target "${{ matrix.target }}" \
             --out-dir dist
-          ASSET="kaist-${TAG}-${TARGET}.tar.gz"
-          (cd dist && shasum -a 256 "${ASSET}" > checksums.txt)
+
+      - name: Upload packaged bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: dist/kaist-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+
+  publish-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packaged bundles
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate combined checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          shasum -a 256 kaist-*.tar.gz > checksums.txt
 
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/kaist-${{ github.ref_name }}-darwin-arm64.tar.gz
+            dist/kaist-${{ github.ref_name }}-darwin-x86_64.tar.gz
             dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current KLMS surface:
 
 ## Install
 
-Managed release install on macOS arm64:
+Managed release install on macOS arm64 or x86_64:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/alazarteka/kaist-cli/main/install.sh | bash

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -7,6 +7,7 @@ This project ships managed standalone CLI bundles through GitHub Releases.
 Each release tag (for example `v0.2.0`) publishes:
 
 - `kaist-v0.2.0-darwin-arm64.tar.gz`
+- `kaist-v0.2.0-darwin-x86_64.tar.gz`
 - `checksums.txt`
 
 The archive must unpack to:
@@ -30,10 +31,10 @@ The archive must unpack to:
 
 The GitHub Actions workflow at `.github/workflows/release.yml`:
 
-1. Builds `kaist` with PyInstaller on `macos-14`.
-2. Calls `scripts/build_release_bundle.sh` to package the managed bundle archive.
-3. Generates `checksums.txt`.
-4. Uploads both assets to the GitHub release for the tag.
+1. Builds `kaist` with PyInstaller on `macos-14` for Apple silicon and `macos-13` for Intel.
+2. Calls `scripts/build_release_bundle.sh` to package one managed bundle archive per target.
+3. Generates a combined `checksums.txt` covering both release archives.
+4. Uploads both archives plus `checksums.txt` to the GitHub release for the tag.
 
 ## Installer Layout
 

--- a/install.sh
+++ b/install.sh
@@ -34,15 +34,18 @@ resolve_target() {
   arch_name="$(uname -m)"
 
   if [[ "$os_name" != "Darwin" ]]; then
-    die "This installer currently supports macOS arm64 only."
+    die "This installer currently supports macOS arm64 and x86_64 only."
   fi
 
   case "$arch_name" in
     arm64|aarch64)
       printf 'darwin-arm64'
       ;;
+    x86_64|amd64)
+      printf 'darwin-x86_64'
+      ;;
     *)
-      die "This installer currently supports macOS arm64 only."
+      die "This installer currently supports macOS arm64 and x86_64 only."
       ;;
   esac
 }
@@ -111,10 +114,6 @@ VERSION_REQUEST="${KAIST_VERSION:-latest}"
 INSTALL_ROOT="${KAIST_INSTALL_ROOT:-$HOME/.local/share/kaist-cli}"
 BIN_DIR="${KAIST_BIN_DIR:-$HOME/.local/bin}"
 TARGET="$(resolve_target)"
-
-if [[ "$TARGET" != "darwin-arm64" ]]; then
-  die "This installer currently supports macOS arm64 only."
-fi
 
 if [[ "$VERSION_REQUEST" == "latest" ]]; then
   TAG="$(fetch_latest_tag "$REPO")"

--- a/src/kaist_cli/v2/klms/auth.py
+++ b/src/kaist_cli/v2/klms/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html as _html
 import json
 import os
 import re
@@ -10,6 +11,9 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
 from .config import KlmsConfig, maybe_load_config, save_config
@@ -39,6 +43,11 @@ APP_LOGIN_PATHS = (
     "/local/applogin/result_login_json.php",
     "/login/ssologin.php",
 )
+
+EASY_LOGIN_VIEW_NEEDLE = "/auth/kaist/user/login/view"
+EASY_LOGIN_SUBMIT_NEEDLE = "/auth/twofactor/mfa/login2Factor"
+EASY_LOGIN_POLL_SECONDS = 1.0
+EASY_LOGIN_DEFAULT_WAIT_SECONDS = 180.0
 
 
 def epoch_to_iso_utc(epoch: float) -> str:
@@ -89,6 +98,67 @@ def extract_sesskey(html: str) -> str | None:
             if value:
                 return value
     return None
+
+
+def _extract_sso_login_view_url(current_url: str, html: str) -> str | None:
+    href_patterns = (
+        r'href=["\']([^"\']*sso\.kaist\.ac\.kr/auth/kaist/user/login/view[^"\']*)["\']',
+        r'href=["\']([^"\']*/auth/kaist/user/login/view[^"\']*)["\']',
+    )
+    for pattern in href_patterns:
+        match = re.search(pattern, html, flags=re.IGNORECASE)
+        if match:
+            href = _html.unescape(match.group(1)).strip()
+            if href:
+                return urljoin(current_url, href)
+    return None
+
+
+def _extract_easy_login_error_message(html: str) -> str | None:
+    soup = BeautifulSoup(html, "html.parser")
+    for selector in ("#mfaResultMsg", "#resultMsg"):
+        node = soup.select_one(selector)
+        if node is None:
+            continue
+        text = " ".join(node.get_text(" ", strip=True).split())
+        if text:
+            return text
+    return None
+
+
+def _extract_easy_login_number(html: str) -> str | None:
+    soup = BeautifulSoup(html, "html.parser")
+    text = " ".join(soup.get_text("\n", strip=True).split())
+    patterns = (
+        r"(?:login|easy login|authentication|approval)\s*(?:number|code)?\s*[:：]?\s*([0-9]{4,8})",
+        r"(?:로그인|간편\s*로그인|인증|승인)\s*(?:번호|코드)?\s*[:：]?\s*([0-9]{4,8})",
+        r"(?:번호|number)\s*[:：]?\s*([0-9]{4,8})",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1)
+
+    for node in soup.find_all(attrs={"id": True}):
+        node_id = str(node.get("id") or "").lower()
+        if any(token in node_id for token in ("auth", "approve", "login", "number", "code")):
+            text = " ".join(node.get_text(" ", strip=True).split())
+            match = re.search(r"\b([0-9]{4,8})\b", text)
+            if match:
+                return match.group(1)
+    for node in soup.find_all(attrs={"class": True}):
+        classes = " ".join(str(value).lower() for value in (node.get("class") or []))
+        if any(token in classes for token in ("auth", "approve", "login", "number", "code")):
+            text = " ".join(node.get_text(" ", strip=True).split())
+            match = re.search(r"\b([0-9]{4,8})\b", text)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _looks_like_easy_login_page(url: str) -> bool:
+    lowered = (url or "").lower()
+    return EASY_LOGIN_VIEW_NEEDLE in lowered or EASY_LOGIN_SUBMIT_NEEDLE in lowered
 
 
 def storage_state_cookie_stats(paths: KlmsPaths) -> dict[str, Any] | None:
@@ -353,6 +423,7 @@ class AuthService:
         return {
             "base_url": config.base_url,
             "dashboard_path": config.dashboard_path,
+            "auth_username": config.auth_username,
             "course_ids": list(config.course_ids),
             "notice_board_ids": list(config.notice_board_ids),
             "exclude_course_title_patterns": list(config.exclude_course_title_patterns),
@@ -453,12 +524,11 @@ class AuthService:
         }
         return CommandResult(data=report, source="bootstrap", capability="partial")
 
-    def login(self, *, base_url: str | None = None, dashboard_path: str | None = None) -> CommandResult:
-        config = save_config(self._paths, base_url=base_url, dashboard_path=dashboard_path)
-        configure_playwright_env(self._paths)
-        self._paths.profile_dir.mkdir(parents=True, exist_ok=True)
-        chmod_best_effort(self._paths.profile_dir, 0o700)
+    def _persist_context_state(self, context: Any) -> None:
+        context.storage_state(path=str(self._paths.storage_state_path))
+        chmod_best_effort(self._paths.storage_state_path, 0o600)
 
+    def _manual_login(self, *, config: KlmsConfig) -> CommandResult:
         from playwright.sync_api import sync_playwright  # type: ignore[import-untyped]
 
         print(f"Opening browser to: {config.base_url}", file=sys.stderr)
@@ -475,10 +545,9 @@ class AuthService:
             page.goto(config.base_url, wait_until="domcontentloaded", timeout=30_000)
             print("Press Enter to save session and exit... ", end="", file=sys.stderr, flush=True)
             input()
-            context.storage_state(path=str(self._paths.storage_state_path))
+            self._persist_context_state(context)
             context.close()
 
-        chmod_best_effort(self._paths.storage_state_path, 0o600)
         return CommandResult(
             data={
                 "ok": True,
@@ -488,13 +557,173 @@ class AuthService:
                 "profile_path": str(self._paths.profile_dir),
                 "storage_state_path": str(self._paths.storage_state_path),
                 "preferred_mode": "profile",
+                "login_strategy": "manual_browser",
             },
             source="browser",
             capability="full",
         )
 
-    def refresh(self, *, base_url: str | None = None, dashboard_path: str | None = None) -> CommandResult:
-        return self.login(base_url=base_url, dashboard_path=dashboard_path)
+    def _wait_for_easy_login_transition(self, page: Any, *, timeout_seconds: float) -> str:
+        deadline = time.monotonic() + max(1.0, timeout_seconds)
+        while time.monotonic() < deadline:
+            current_url = str(page.url or "")
+            html = page.content()
+            error_message = _extract_easy_login_error_message(html)
+            if error_message:
+                raise CommandError(
+                    code="AUTH_FAILED",
+                    message=f"KAIST Easy Login rejected the username ({error_message}).",
+                    hint="Check the KAIST account ID and confirm Easy Login is registered in the KAIST auth app.",
+                    exit_code=10,
+                    retryable=False,
+                )
+            if EASY_LOGIN_SUBMIT_NEEDLE in current_url or "/auth/twofactor/mfa/" in current_url:
+                return html
+            if not _looks_like_easy_login_page(current_url):
+                return html
+            page.wait_for_timeout(250)
+        raise CommandError(
+            code="AUTH_TIMEOUT",
+            message="Timed out waiting for KAIST Easy Login to initialize.",
+            hint="Try again, or fall back to `kaist klms auth login` without `--username`.",
+            exit_code=10,
+            retryable=True,
+        )
+
+    def _easy_login(self, *, config: KlmsConfig, username: str, wait_seconds: float) -> CommandResult:
+        from playwright.sync_api import sync_playwright  # type: ignore[import-untyped]
+
+        wait_seconds = max(15.0, min(float(wait_seconds), 600.0))
+        printed_login_number: str | None = None
+        with sync_playwright() as playwright:
+            context = _launch_chromium_persistent_context_sync(
+                playwright,
+                paths=self._paths,
+                user_data_dir=str(self._paths.profile_dir),
+                headless=True,
+                accept_downloads=False,
+            )
+            try:
+                page = context.new_page()
+                page.goto(config.base_url, wait_until="domcontentloaded", timeout=30_000)
+                html = page.content()
+                current_url = str(page.url or "")
+                sso_url = _extract_sso_login_view_url(current_url, html)
+                if not sso_url:
+                    if _looks_like_easy_login_page(current_url):
+                        sso_url = current_url
+                    else:
+                        raise CommandError(
+                            code="AUTH_FLOW_UNSUPPORTED",
+                            message="Could not locate the KAIST SSO Easy Login page from the KLMS login flow.",
+                            hint="Run `kaist klms auth login` without `--username` to use the manual browser flow.",
+                            exit_code=10,
+                            retryable=False,
+                        )
+                page.goto(sso_url, wait_until="networkidle", timeout=30_000)
+                page.fill("#login_id_mfa", username)
+                page.click("a.btn_login")
+                html = self._wait_for_easy_login_transition(page, timeout_seconds=12.0)
+                login_number = _extract_easy_login_number(html)
+                if login_number:
+                    printed_login_number = login_number
+                    print(f"KAIST SSO Easy Login number: {login_number}", file=sys.stderr)
+                    print("Approve this login in the KAIST auth app. Waiting for KLMS session...", file=sys.stderr)
+                else:
+                    print("KAIST SSO Easy Login initialized. Waiting for approval in the KAIST auth app...", file=sys.stderr)
+
+                auth_deadline = time.monotonic() + wait_seconds
+                last_auth_check = 0.0
+                while time.monotonic() < auth_deadline:
+                    now = time.monotonic()
+                    if now - last_auth_check >= EASY_LOGIN_POLL_SECONDS:
+                        last_auth_check = now
+                        state = self._context_dashboard_state(context, config=config, timeout_ms=5_000)
+                        if state["authenticated"]:
+                            self._persist_context_state(context)
+                            return CommandResult(
+                                data={
+                                    "ok": True,
+                                    "base_url": config.base_url,
+                                    "dashboard_path": config.dashboard_path,
+                                    "config_path": str(self._paths.config_path),
+                                    "profile_path": str(self._paths.profile_dir),
+                                    "storage_state_path": str(self._paths.storage_state_path),
+                                    "preferred_mode": "profile",
+                                    "login_strategy": "sso_easy_login",
+                                    "username": username,
+                                    "login_number": printed_login_number,
+                                },
+                                source="browser",
+                                capability="full",
+                            )
+
+                    current_html = page.content()
+                    current_url = str(page.url or "")
+                    error_message = _extract_easy_login_error_message(current_html)
+                    if error_message:
+                        raise CommandError(
+                            code="AUTH_FAILED",
+                            message=f"KAIST Easy Login failed after initialization ({error_message}).",
+                            hint="Try again, or fall back to `kaist klms auth login` without `--username`.",
+                            exit_code=10,
+                            retryable=False,
+                        )
+                    current_number = _extract_easy_login_number(current_html)
+                    if current_number and current_number != printed_login_number:
+                        printed_login_number = current_number
+                        print(f"KAIST SSO Easy Login number: {current_number}", file=sys.stderr)
+                    page.wait_for_timeout(int(EASY_LOGIN_POLL_SECONDS * 1000))
+
+                detail = f" Login number: {printed_login_number}." if printed_login_number else ""
+                raise CommandError(
+                    code="AUTH_TIMEOUT",
+                    message=f"Timed out waiting for KAIST Easy Login approval.{detail}",
+                    hint="Approve the request in the KAIST auth app faster, or use `kaist klms auth login` without `--username`.",
+                    exit_code=10,
+                    retryable=True,
+                )
+            finally:
+                context.close()
+
+    def login(
+        self,
+        *,
+        base_url: str | None = None,
+        dashboard_path: str | None = None,
+        username: str | None = None,
+        wait_seconds: float = EASY_LOGIN_DEFAULT_WAIT_SECONDS,
+    ) -> CommandResult:
+        normalized_username = str(username or "").strip()
+        config = save_config(
+            self._paths,
+            base_url=base_url,
+            dashboard_path=dashboard_path,
+            auth_username=normalized_username if normalized_username else None,
+        )
+        configure_playwright_env(self._paths)
+        self._paths.profile_dir.mkdir(parents=True, exist_ok=True)
+        chmod_best_effort(self._paths.profile_dir, 0o700)
+        if normalized_username:
+            return self._easy_login(config=config, username=normalized_username, wait_seconds=wait_seconds)
+        return self._manual_login(config=config)
+
+    def refresh(
+        self,
+        *,
+        base_url: str | None = None,
+        dashboard_path: str | None = None,
+        username: str | None = None,
+        wait_seconds: float = EASY_LOGIN_DEFAULT_WAIT_SECONDS,
+    ) -> CommandResult:
+        existing = maybe_load_config(self._paths)
+        resolved_username = str(username or "").strip() or (existing.auth_username if existing else None)
+        return self.login(
+            base_url=base_url,
+            dashboard_path=dashboard_path,
+            username=resolved_username,
+            wait_seconds=wait_seconds,
+        )
 
     def _context_dashboard_state(self, context: Any, *, config: KlmsConfig, timeout_ms: int) -> dict[str, Any]:
         page = context.new_page()

--- a/src/kaist_cli/v2/klms/commands.py
+++ b/src/kaist_cli/v2/klms/commands.py
@@ -8,13 +8,23 @@ from .container import KlmsFacade
 
 def dispatch(args: argparse.Namespace, facade: KlmsFacade) -> CommandResult:
     if args.group == "auth" and args.action == "login":
-        return facade.auth_login(base_url=args.base_url, dashboard_path=args.dashboard_path)
+        return facade.auth_login(
+            base_url=args.base_url,
+            dashboard_path=args.dashboard_path,
+            username=args.username,
+            wait_seconds=args.wait_seconds,
+        )
     if args.group == "auth" and args.action == "install-browser":
         return facade.auth_install_browser(force=args.force)
     if args.group == "auth" and args.action == "status":
         return facade.auth_status()
     if args.group == "auth" and args.action == "refresh":
-        return facade.auth_refresh(base_url=args.base_url, dashboard_path=args.dashboard_path)
+        return facade.auth_refresh(
+            base_url=args.base_url,
+            dashboard_path=args.dashboard_path,
+            username=args.username,
+            wait_seconds=args.wait_seconds,
+        )
     if args.group == "auth" and args.action == "doctor":
         return facade.auth_doctor()
     if args.group == "today":

--- a/src/kaist_cli/v2/klms/config.py
+++ b/src/kaist_cli/v2/klms/config.py
@@ -13,6 +13,7 @@ from .paths import KlmsPaths, ensure_private_dirs
 class KlmsConfig:
     base_url: str
     dashboard_path: str
+    auth_username: str | None
     course_ids: tuple[str, ...]
     notice_board_ids: tuple[str, ...]
     exclude_course_title_patterns: tuple[str, ...]
@@ -42,6 +43,11 @@ def _normalize_dashboard_path(value: str | None) -> str:
     if not dashboard_path.startswith("/"):
         dashboard_path = "/" + dashboard_path
     return dashboard_path
+
+
+def _normalize_auth_username(value: str | None) -> str | None:
+    username = (value or "").strip()
+    return username or None
 
 
 def _coerce_list(raw: Any, *, field_name: str) -> tuple[str, ...]:
@@ -86,6 +92,7 @@ def load_config(paths: KlmsPaths) -> KlmsConfig:
     return KlmsConfig(
         base_url=_normalize_base_url(str(data.get("base_url", ""))),
         dashboard_path=_normalize_dashboard_path(str(data.get("dashboard_path", "/my/"))),
+        auth_username=_normalize_auth_username(data.get("auth_username")),
         course_ids=_coerce_list(data.get("course_ids"), field_name="course_ids"),
         notice_board_ids=_coerce_list(data.get("notice_board_ids"), field_name="notice_board_ids"),
         exclude_course_title_patterns=_coerce_list(
@@ -107,11 +114,17 @@ def save_config(
     *,
     base_url: str | None = None,
     dashboard_path: str | None = None,
+    auth_username: str | None = None,
 ) -> KlmsConfig:
     ensure_private_dirs(paths)
     existing = maybe_load_config(paths)
     resolved_base_url = _normalize_base_url(base_url or (existing.base_url if existing else ""))
     resolved_dashboard_path = _normalize_dashboard_path(dashboard_path or (existing.dashboard_path if existing else "/my/"))
+    resolved_auth_username = (
+        _normalize_auth_username(auth_username)
+        if auth_username is not None
+        else (existing.auth_username if existing else None)
+    )
 
     course_ids = existing.course_ids if existing else ()
     notice_board_ids = existing.notice_board_ids if existing else ()
@@ -120,6 +133,7 @@ def save_config(
     lines = [
         f"base_url = {_toml_quote(resolved_base_url)}",
         f"dashboard_path = {_toml_quote(resolved_dashboard_path)}",
+        f"auth_username = {_toml_quote(resolved_auth_username or '')}",
         f"course_ids = {json.dumps(list(course_ids), ensure_ascii=False)}",
         f"notice_board_ids = {json.dumps(list(notice_board_ids), ensure_ascii=False)}",
         f"exclude_course_title_patterns = {json.dumps(list(exclude_course_title_patterns), ensure_ascii=False)}",
@@ -130,6 +144,7 @@ def save_config(
     return KlmsConfig(
         base_url=resolved_base_url,
         dashboard_path=resolved_dashboard_path,
+        auth_username=resolved_auth_username,
         course_ids=course_ids,
         notice_board_ids=notice_board_ids,
         exclude_course_title_patterns=exclude_course_title_patterns,

--- a/src/kaist_cli/v2/klms/container.py
+++ b/src/kaist_cli/v2/klms/container.py
@@ -40,8 +40,20 @@ class KlmsFacade:
         self._courses = courses
         self._videos = videos
 
-    def auth_login(self, *, base_url: str | None = None, dashboard_path: str | None = None) -> CommandResult:
-        return self._auth.login(base_url=base_url, dashboard_path=dashboard_path)
+    def auth_login(
+        self,
+        *,
+        base_url: str | None = None,
+        dashboard_path: str | None = None,
+        username: str | None = None,
+        wait_seconds: float = 180.0,
+    ) -> CommandResult:
+        return self._auth.login(
+            base_url=base_url,
+            dashboard_path=dashboard_path,
+            username=username,
+            wait_seconds=wait_seconds,
+        )
 
     def auth_install_browser(self, *, force: bool = False) -> CommandResult:
         return self._auth.install_browser(force=force)
@@ -49,8 +61,20 @@ class KlmsFacade:
     def auth_status(self) -> CommandResult:
         return self._auth.status()
 
-    def auth_refresh(self, *, base_url: str | None = None, dashboard_path: str | None = None) -> CommandResult:
-        return self._auth.refresh(base_url=base_url, dashboard_path=dashboard_path)
+    def auth_refresh(
+        self,
+        *,
+        base_url: str | None = None,
+        dashboard_path: str | None = None,
+        username: str | None = None,
+        wait_seconds: float = 180.0,
+    ) -> CommandResult:
+        return self._auth.refresh(
+            base_url=base_url,
+            dashboard_path=dashboard_path,
+            username=username,
+            wait_seconds=wait_seconds,
+        )
 
     def auth_doctor(self) -> CommandResult:
         return self._auth.doctor()

--- a/src/kaist_cli/v2/parser.py
+++ b/src/kaist_cli/v2/parser.py
@@ -41,6 +41,8 @@ def register_klms_parser(
     auth_login = auth_sub.add_parser("login", help="Interactive login bootstrap", formatter_class=_HelpFormatter)
     auth_login.add_argument("--base-url", metavar="URL", help="Persist this KLMS base URL before opening the browser.")
     auth_login.add_argument("--dashboard-path", metavar="PATH", help="Optional dashboard path override, default /my/.")
+    auth_login.add_argument("--username", metavar="ID", help="Use KAIST SSO Easy Login with this KAIST account ID instead of the manual browser flow.")
+    auth_login.add_argument("--wait-seconds", type=float, default=180.0, metavar="N", help="Maximum time to wait for KAIST Easy Login approval.")
     _set_defaults(auth_login, schema_name=f"{schema_prefix}.auth.login.v1", command_path="klms auth login", handler=handler)
 
     auth_install = auth_sub.add_parser(
@@ -62,6 +64,8 @@ def register_klms_parser(
     auth_refresh = auth_sub.add_parser("refresh", help="Refresh existing auth", formatter_class=_HelpFormatter)
     auth_refresh.add_argument("--base-url", metavar="URL", help="Optional base URL override before refreshing auth.")
     auth_refresh.add_argument("--dashboard-path", metavar="PATH", help="Optional dashboard path override, default /my/.")
+    auth_refresh.add_argument("--username", metavar="ID", help="Use KAIST SSO Easy Login with this KAIST account ID instead of the manual browser flow.")
+    auth_refresh.add_argument("--wait-seconds", type=float, default=180.0, metavar="N", help="Maximum time to wait for KAIST Easy Login approval.")
     _set_defaults(
         auth_refresh,
         schema_name=f"{schema_prefix}.auth.refresh.v1",

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -59,11 +59,11 @@ def _write_fake_binary(path: Path) -> None:
     os.chmod(path, 0o755)
 
 
-def _prepare_release_dir(base_dir: Path, version: str) -> tuple[Path, Path]:
+def _prepare_release_dir(base_dir: Path, version: str, *, target: str = "darwin-arm64") -> tuple[Path, Path]:
     tag = version if version.startswith("v") else f"v{version}"
     release_dir = base_dir / tag
     release_dir.mkdir(parents=True, exist_ok=True)
-    binary_path = base_dir / f"kaist-{tag}"
+    binary_path = base_dir / f"kaist-{tag}-{target}"
     _write_fake_binary(binary_path)
     cp = subprocess.run(
         [
@@ -74,7 +74,7 @@ def _prepare_release_dir(base_dir: Path, version: str) -> tuple[Path, Path]:
             "--version",
             tag,
             "--target",
-            "darwin-arm64",
+            target,
             "--out-dir",
             str(release_dir),
         ],
@@ -84,7 +84,7 @@ def _prepare_release_dir(base_dir: Path, version: str) -> tuple[Path, Path]:
         check=False,
     )
     assert cp.returncode == 0, cp.stderr
-    archive_path = release_dir / f"kaist-{tag}-darwin-arm64.tar.gz"
+    archive_path = release_dir / f"kaist-{tag}-{target}.tar.gz"
     checksums_path = release_dir / "checksums.txt"
     checksums_path.write_text(
         f"{updater._sha256(archive_path)}  {archive_path.name}\n",
@@ -149,8 +149,9 @@ def test_check_for_update_includes_distribution_metadata(monkeypatch: pytest.Mon
     assert payload["self_update_supported"] is False
 
 
-def test_build_release_bundle_contains_skill_and_manifest(tmp_path: Path) -> None:
-    archive_path, _ = _prepare_release_dir(tmp_path / "releases", "v0.1.4")
+@pytest.mark.parametrize("target", ["darwin-arm64", "darwin-x86_64"])
+def test_build_release_bundle_contains_skill_and_manifest(tmp_path: Path, target: str) -> None:
+    archive_path, _ = _prepare_release_dir(tmp_path / "releases", "v0.1.4", target=target)
 
     with tarfile.open(archive_path, "r:gz") as tar:
         names = {name.lstrip("./") for name in tar.getnames()}
@@ -163,16 +164,17 @@ def test_build_release_bundle_contains_skill_and_manifest(tmp_path: Path) -> Non
     assert manifest == {
         "version": "0.1.4",
         "repo": updater.RELEASE_REPO,
-        "target": "darwin-arm64",
+        "target": target,
         "binary_relpath": "bin/kaist",
         "skill_relpath": "skills/kaist-cli",
     }
 
 
-def test_install_script_installs_managed_layout_and_rotates_previous(tmp_path: Path) -> None:
+@pytest.mark.parametrize("target", ["darwin-arm64", "darwin-x86_64"])
+def test_install_script_installs_managed_layout_and_rotates_previous(tmp_path: Path, target: str) -> None:
     downloads_dir = tmp_path / "downloads"
-    _prepare_release_dir(downloads_dir, "v0.1.4")
-    _prepare_release_dir(downloads_dir, "v0.1.5")
+    _prepare_release_dir(downloads_dir, "v0.1.4", target=target)
+    _prepare_release_dir(downloads_dir, "v0.1.5", target=target)
     latest_json = tmp_path / "latest.json"
     latest_json.write_text(json.dumps({"tag_name": "v0.1.4"}), encoding="utf-8")
 
@@ -185,7 +187,7 @@ def test_install_script_installs_managed_layout_and_rotates_previous(tmp_path: P
             "KAIST_DOWNLOAD_BASE_URL": downloads_dir.resolve().as_uri(),
             "KAIST_INSTALL_ROOT": str(install_root),
             "KAIST_BIN_DIR": str(bin_dir),
-            "KAIST_PLATFORM_TARGET": "darwin-arm64",
+            "KAIST_PLATFORM_TARGET": target,
         }
     )
 

--- a/tests/test_v2_cli.py
+++ b/tests/test_v2_cli.py
@@ -16,10 +16,12 @@ sys.path.insert(0, str(ROOT / "src"))
 from kaist_cli.v2.contracts import CommandResult
 from kaist_cli.v2.klms.cache import load_cache_entry, load_cache_value, save_cache_value
 from kaist_cli.v2.klms import dashboard as dashboard_module
-from kaist_cli.v2.klms.auth import looks_login_url
+from kaist_cli.v2.klms.auth import AuthService
+from kaist_cli.v2.klms.auth import _extract_easy_login_error_message, _extract_easy_login_number, _extract_sso_login_view_url, looks_login_url
 from kaist_cli.v2.klms.assignments import _extract_assignment_detail_from_html, _extract_assignment_rows_from_calendar_data
 from kaist_cli.v2.klms.courses import _parse_recent_courses_payload
 from kaist_cli.v2.klms.capture import _courseboard_runtime_capture_summary, _extract_courseboard_js_hints
+from kaist_cli.v2.klms.config import load_config
 from kaist_cli.v2.klms.dashboard import DashboardService, _build_inbox_items, _decorate_today_assignments, _filter_inbox_assignments, _select_recent_notices
 from kaist_cli.v2.klms.discovery import load_recent_courses_args, map_discovery_report
 from kaist_cli.v2.klms.files import _extract_file_items_from_course_contents, _extract_file_items_from_html, _pull_subdir_for_item, _sanitize_relpath, _synthesize_file_item_from_url, _unwrap_moodle_ajax_payload
@@ -44,7 +46,13 @@ def run_v2(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _write_config(tmp_path: Path, *, base_url: str = "https://klms.kaist.ac.kr", dashboard_path: str = "/my/") -> Path:
+def _write_config(
+    tmp_path: Path,
+    *,
+    base_url: str = "https://klms.kaist.ac.kr",
+    dashboard_path: str = "/my/",
+    auth_username: str | None = None,
+) -> Path:
     config_path = tmp_path / "kaist-home" / "private" / "klms" / "config.toml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
@@ -52,6 +60,7 @@ def _write_config(tmp_path: Path, *, base_url: str = "https://klms.kaist.ac.kr",
             [
                 f'base_url = "{base_url}"',
                 f'dashboard_path = "{dashboard_path}"',
+                f'auth_username = "{auth_username or ""}"',
                 "course_ids = []",
                 "notice_board_ids = []",
                 "exclude_course_title_patterns = []",
@@ -110,6 +119,45 @@ def test_auth_status_detects_storage_state_and_cookie_stats(tmp_path: Path) -> N
     assert payload["data"]["storage_state_cookie_stats"]["next_expiry_iso"] is not None
 
 
+def test_auth_status_includes_saved_auth_username(tmp_path: Path) -> None:
+    _write_config(tmp_path, auth_username="student123")
+
+    cp = run_v2(tmp_path, "--json", "klms", "auth", "status")
+    assert cp.returncode == 0, cp.stderr
+    payload = json.loads(cp.stdout)
+    assert payload["data"]["config"]["auth_username"] == "student123"
+
+
+def test_auth_refresh_uses_saved_auth_username(tmp_path: Path, monkeypatch) -> None:
+    _write_config(tmp_path, auth_username="student123")
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(tmp_path / "kaist-home")
+    try:
+        auth = AuthService(resolve_paths())
+        calls: list[dict[str, object]] = []
+
+        def fake_login(*, base_url=None, dashboard_path=None, username=None, wait_seconds=180.0):
+            calls.append(
+                {
+                    "base_url": base_url,
+                    "dashboard_path": dashboard_path,
+                    "username": username,
+                    "wait_seconds": wait_seconds,
+                }
+            )
+            return CommandResult(data={"ok": True}, source="bootstrap", capability="partial")
+
+        monkeypatch.setattr(auth, "login", fake_login)
+        auth.refresh()
+        assert calls
+        assert calls[0]["username"] == "student123"
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+
+
 def test_dev_plan_json_envelope(tmp_path: Path) -> None:
     cp = run_v2(tmp_path, "--json", "klms", "dev", "plan")
     assert cp.returncode == 0, cp.stderr
@@ -145,6 +193,28 @@ def test_dev_probe_live_without_config_is_structured(tmp_path: Path) -> None:
 
 def test_custom_login_url_detection_is_enabled() -> None:
     assert looks_login_url("https://klms.kaist.ac.kr/local/applogin/result_login_json.php?userid=test")
+
+
+def test_extract_sso_login_view_url_from_klms_login_shell() -> None:
+    html = """
+    <html><body>
+      <a href="https://sso.kaist.ac.kr/auth/kaist/user/login/view?agt_id=kaist-prod-klms">Log in</a>
+    </body></html>
+    """
+    assert _extract_sso_login_view_url("https://klms.kaist.ac.kr/login/ssologin.php", html) == (
+        "https://sso.kaist.ac.kr/auth/kaist/user/login/view?agt_id=kaist-prod-klms"
+    )
+
+
+def test_extract_easy_login_number_and_error_message() -> None:
+    html = """
+    <html><body>
+      <div id="authNumber">Login Number: 482913</div>
+      <label id="mfaResultMsg">Easy Login app is not registered.</label>
+    </body></html>
+    """
+    assert _extract_easy_login_number(html) == "482913"
+    assert _extract_easy_login_error_message(html) == "Easy Login app is not registered."
 
 
 def test_recent_courses_args_load_from_api_map(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add KAIST SSO Easy Login auth bootstrap with saved auth username reuse\n- persist auth_username in KLMS config and reuse it during auth refresh\n- publish both darwin-arm64 and darwin-x86_64 managed release bundles\n- make install.sh auto-detect the correct macOS target\n\n## Testing\n- PYTHONPYCACHEPREFIX=/tmp/kaist-cli-pyc uv run --with pytest pytest -q tests/test_updater.py tests/test_v2_cli.py\n- scripts/build_release_bundle.sh --binary /tmp/kaist-x64-bundle/kaist --version v0.2.0 --target darwin-x86_64 --out-dir /tmp/kaist-x64-bundle\n- KAIST_CLI_HOME=<tmp> PYTHONPATH=src uv run python -m kaist_cli.main --agent klms auth login --base-url https://klms.kaist.ac.kr --username doesnotexist123 --wait-seconds 10