### PR TITLE
Bump version for v0.3.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kaist-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "CLI for KAIST systems (starting with KLMS)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/kaist_cli/__init__.py
+++ b/src/kaist_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ wheels = [
 
 [[package]]
 name = "kaist-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary\n- bump the packaged CLI version to 0.3.0\n- align the new SSO easy-login flow and Intel macOS release support with a tagged release\n\n## Testing\n- PYTHONPYCACHEPREFIX=/tmp/kaist-cli-pyc uv run --with pytest pytest -q tests/test_updater.py tests/test_v2_cli.py\n- PYTHONPATH=src uv run python -m kaist_cli.main --agent version