### PR TITLE
Fix Intel macOS release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           - target: darwin-arm64
             runner: macos-14
           - target: darwin-x86_64
-            runner: macos-13
+            runner: macos-15-intel
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -31,7 +31,7 @@ The archive must unpack to:
 
 The GitHub Actions workflow at `.github/workflows/release.yml`:
 
-1. Builds `kaist` with PyInstaller on `macos-14` for Apple silicon and `macos-13` for Intel.
+1. Builds `kaist` with PyInstaller on `macos-14` for Apple silicon and `macos-15-intel` for Intel.
 2. Calls `scripts/build_release_bundle.sh` to package one managed bundle archive per target.
 3. Generates a combined `checksums.txt` covering both release archives.
 4. Uploads both archives plus `checksums.txt` to the GitHub release for the tag.


### PR DESCRIPTION
## Summary\n- switch the Intel macOS release build to the supported  runner label\n- update release docs to match\n\n## Testing\n- PYTHONPYCACHEPREFIX=/tmp/kaist-cli-pyc uv run --with pytest pytest -q tests/test_updater.py