### PR TITLE
Fix SSO easy login number extraction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,53 @@ prune_versions() {
   done
 }
 
+sync_claude_marketplace() {
+  local install_root="$1"
+  local version="$2"
+  local marketplace_root plugin_root skill_target skill_link plugin_json marketplace_json
+  marketplace_root="$install_root/mkt"
+  plugin_root="$marketplace_root/plugins/kaist-cli"
+  skill_target="$install_root/current/skills/kaist-cli"
+  skill_link="$plugin_root/skills/kaist-cli"
+  plugin_json="$plugin_root/.claude-plugin/plugin.json"
+  marketplace_json="$marketplace_root/.claude-plugin/marketplace.json"
+
+  mkdir -p "$plugin_root/.claude-plugin" "$(dirname "$skill_link")" "$(dirname "$marketplace_json")"
+  rm -rf "$skill_link"
+  ln -sfn "$skill_target" "$skill_link"
+
+  cat >"$plugin_json" <<JSON
+{
+  "name": "kaist-cli",
+  "description": "Operate KLMS through the installed kaist CLI.",
+  "author": {
+    "name": "kaist-cli"
+  }
+}
+JSON
+
+  cat >"$marketplace_json" <<JSON
+{
+  "name": "kaist-cli",
+  "owner": {
+    "name": "kaist-cli"
+  },
+  "plugins": [
+    {
+      "name": "kaist-cli",
+      "description": "Operate KLMS through the installed kaist CLI.",
+      "version": "${version}",
+      "author": {
+        "name": "kaist-cli"
+      },
+      "source": "./plugins/kaist-cli",
+      "category": "productivity"
+    }
+  ]
+}
+JSON
+}
+
 REPO="${KAIST_RELEASE_REPO:-alazarteka/kaist-cli}"
 VERSION_REQUEST="${KAIST_VERSION:-latest}"
 INSTALL_ROOT="${KAIST_INSTALL_ROOT:-$HOME/.local/share/kaist-cli}"
@@ -171,6 +218,7 @@ keep_previous="$(resolve_dir_link "$previous_link" || true)"
 prune_versions "$INSTALL_ROOT" "$keep_current" "$keep_previous"
 
 ln -sfn "$INSTALL_ROOT/current/bin/kaist" "$bin_link"
+sync_claude_marketplace "$INSTALL_ROOT" "${TAG#v}" || warn "Could not sync Claude plugin marketplace metadata."
 
 skill_path="$INSTALL_ROOT/current/skills/kaist-cli"
 printf 'Installed kaist %s to %s\n' "${TAG#v}" "$INSTALL_ROOT/current"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kaist-cli"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI for KAIST systems (starting with KLMS)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/kaist_cli/__init__.py
+++ b/src/kaist_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/src/kaist_cli/core/updater.py
+++ b/src/kaist_cli/core/updater.py
@@ -304,6 +304,53 @@ def _prune_versions(ctx: ManagedInstallContext, keep_roots: set[Path]) -> list[s
     return warnings
 
 
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _sync_claude_plugin_metadata(install_root: Path, *, version: str) -> Path:
+    marketplace_root = install_root / "mkt"
+    plugin_root = marketplace_root / "plugins" / "kaist-cli"
+    plugin_manifest_path = plugin_root / ".claude-plugin" / "plugin.json"
+    marketplace_manifest_path = marketplace_root / ".claude-plugin" / "marketplace.json"
+    skill_target = install_root / "current" / "skills" / "kaist-cli"
+    skill_link = plugin_root / "skills" / "kaist-cli"
+
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    skill_link.parent.mkdir(parents=True, exist_ok=True)
+    if skill_link.exists() or skill_link.is_symlink():
+        _remove_path(skill_link)
+    skill_link.symlink_to(skill_target, target_is_directory=True)
+
+    _write_json(
+        plugin_manifest_path,
+        {
+            "name": "kaist-cli",
+            "description": "Operate KLMS through the installed kaist CLI.",
+            "author": {"name": "kaist-cli"},
+        },
+    )
+    _write_json(
+        marketplace_manifest_path,
+        {
+            "name": "kaist-cli",
+            "owner": {"name": "kaist-cli"},
+            "plugins": [
+                {
+                    "name": "kaist-cli",
+                    "description": "Operate KLMS through the installed kaist CLI.",
+                    "version": str(version),
+                    "author": {"name": "kaist-cli"},
+                    "source": "./plugins/kaist-cli",
+                    "category": "productivity",
+                }
+            ],
+        },
+    )
+    return marketplace_manifest_path
+
+
 def check_for_update() -> dict[str, Any]:
     current = version_string()
     target = platform_target()
@@ -395,6 +442,11 @@ def perform_self_update() -> dict[str, Any]:
     if previous_kept is not None:
         keep_roots.add(previous_kept)
     warnings = _prune_versions(ctx, keep_roots)
+    claude_marketplace_path: str | None = None
+    try:
+        claude_marketplace_path = str(_sync_claude_plugin_metadata(ctx.install_root, version=manifest.version))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not sync Claude plugin marketplace: {exc}")
 
     current_bundle_root = ctx.current_link
     bundled_skill_path = current_bundle_root / manifest.skill_relpath
@@ -407,6 +459,7 @@ def perform_self_update() -> dict[str, Any]:
         "binary_path": str(installed_binary_path),
         "install_root": str(ctx.install_root),
         "bundled_skill_path": str(bundled_skill_path),
+        "claude_marketplace_path": claude_marketplace_path,
         "previous_version": previous_root.name if previous_root is not None else None,
         "message": "Update installed. Restart the kaist command.",
     }

--- a/src/kaist_cli/v2/klms/auth.py
+++ b/src/kaist_cli/v2/klms/auth.py
@@ -128,10 +128,23 @@ def _extract_easy_login_error_message(html: str) -> str | None:
 
 def _extract_easy_login_number(html: str) -> str | None:
     soup = BeautifulSoup(html, "html.parser")
+    for selector in (
+        ".auth_number .nember_wrap",
+        ".auth_number [aria-hidden='false']",
+        ".auth_number .sr-only",
+        "#authNumber",
+    ):
+        node = soup.select_one(selector)
+        if node is None:
+            continue
+        digits = re.sub(r"\D+", "", node.get_text("", strip=True))
+        if 2 <= len(digits) <= 8:
+            return digits
+
     text = " ".join(soup.get_text("\n", strip=True).split())
     patterns = (
-        r"(?:login|easy login|authentication|approval)\s*(?:number|code)?\s*[:：]?\s*([0-9]{4,8})",
-        r"(?:로그인|간편\s*로그인|인증|승인)\s*(?:번호|코드)?\s*[:：]?\s*([0-9]{4,8})",
+        r"(?:verification\s*code|login|easy login|authentication|approval)\s*(?:number|code)?\s*[:：]?\s*([0-9]{2,8})",
+        r"(?:인증\s*코드|로그인|간편\s*로그인|인증|승인)\s*(?:번호|코드)?\s*[:：]?\s*([0-9]{2,8})",
         r"(?:번호|number)\s*[:：]?\s*([0-9]{4,8})",
     )
     for pattern in patterns:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -203,6 +203,8 @@ def test_install_script_installs_managed_layout_and_rotates_previous(tmp_path: P
     assert (install_root / "current").resolve().name == "v0.1.4"
     assert not (install_root / "previous").exists()
     assert (install_root / "current" / "skills" / "kaist-cli" / "SKILL.md").exists()
+    assert json.loads((install_root / "mkt" / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))["plugins"][0]["version"] == "0.1.4"
+    assert (install_root / "mkt" / "plugins" / "kaist-cli" / "skills" / "kaist-cli").is_symlink()
     assert "Bundled skill:" in first.stdout
 
     stale = install_root / "versions" / "v0.1.0"
@@ -222,6 +224,7 @@ def test_install_script_installs_managed_layout_and_rotates_previous(tmp_path: P
     assert (install_root / "previous").resolve().name == "v0.1.4"
     assert not stale.exists()
     assert (bin_dir / "kaist").resolve() == (install_root / "current" / "bin" / "kaist").resolve()
+    assert json.loads((install_root / "mkt" / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))["plugins"][0]["version"] == "0.1.5"
 
 
 def test_perform_self_update_switches_current_and_previous(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -263,9 +266,11 @@ def test_perform_self_update_switches_current_and_previous(tmp_path: Path, monke
 
     assert payload["updated"] is True
     assert payload["bundled_skill_path"] == str(install_root / "current" / "skills" / "kaist-cli")
+    assert payload["claude_marketplace_path"] == str(install_root / "mkt" / ".claude-plugin" / "marketplace.json")
     assert (install_root / "current").resolve().name == "v0.1.5"
     assert (install_root / "previous").resolve().name == "v0.1.4"
     assert not stale.exists()
+    assert json.loads((install_root / "mkt" / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))["plugins"][0]["version"] == "0.1.5"
 
 
 def test_prune_versions_returns_warning_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_v2_cli.py
+++ b/tests/test_v2_cli.py
@@ -217,6 +217,22 @@ def test_extract_easy_login_number_and_error_message() -> None:
     assert _extract_easy_login_error_message(html) == "Easy Login app is not registered."
 
 
+def test_extract_easy_login_number_from_verification_widget() -> None:
+    html = """
+    <html><body>
+      <div class="auth_number">
+        <em></em>
+        <div class="nember_wrap">
+          <span>5</span>
+          <span>0</span>
+        </div>
+        <div style="font-size:0;" class="sr-only" aria-hidden="false" tabindex="0">50</div>
+      </div>
+    </body></html>
+    """
+    assert _extract_easy_login_number(html) == "50"
+
+
 def test_recent_courses_args_load_from_api_map(tmp_path: Path) -> None:
     private_root = tmp_path / "kaist-home" / "private" / "klms"
     private_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- extract the KAIST Easy Login verification number from the real verification widget
- keep Claude marketplace metadata in sync during install/update
- bump version to 0.3.2

## Testing
- PYTHONPYCACHEPREFIX=/tmp/kaist-cli-pyc uv run --with pytest pytest -q tests/test_updater.py tests/test_v2_cli.py
- .venv/bin/python -m kaist_cli.main --agent klms auth login --base-url https://klms.kaist.ac.kr --username alazart --wait-seconds 15