### PR TITLE
Fix silent-failure and defensive AI slop (PR1/6)

### DIFF
--- a/src/kaist_cli/core/runtime.py
+++ b/src/kaist_cli/core/runtime.py
@@ -11,11 +11,6 @@ class RuntimeConfig:
 
 @dataclass(frozen=True)
 class SharedAuthRuntime:
-    """
-    Shared runtime marker for systems that use browser/session auth.
-
-    System adapters can compose their own runtime implementations while sharing
-    this common config object.
-    """
+    """Shared browser/session auth runtime config for system adapters."""
 
     config: RuntimeConfig = RuntimeConfig()

--- a/src/kaist_cli/core/state_store.py
+++ b/src/kaist_cli/core/state_store.py
@@ -9,12 +9,7 @@ from typing import Any, Callable, Iterator
 
 @contextmanager
 def file_lock(lock_path: Path, *, blocking: bool = True) -> Iterator[None]:
-    """
-    Process-level advisory lock for file-backed state.
-
-    Uses flock on Unix. The lock file is separate from the data file to keep
-    read/write call sites straightforward.
-    """
+    """Process-level advisory flock; lock file is separate from the data file."""
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     handle = open(lock_path, "a+b")
     try:

--- a/src/kaist_cli/core/updater.py
+++ b/src/kaist_cli/core/updater.py
@@ -254,15 +254,12 @@ def _content_length_from_response(response: Any) -> int | None:
     headers = getattr(response, "headers", None)
     if headers is None:
         return None
-    try:
-        content_length = headers.get("Content-Length")
-    except Exception:
-        content_length = None
+    content_length = headers.get("Content-Length")
     if content_length in {None, ""}:
         return None
     try:
         value = int(content_length)
-    except Exception:
+    except (TypeError, ValueError):
         return None
     return value if value > 0 else None
 
@@ -604,18 +601,21 @@ def _sync_claude_plugin_metadata(install_root: Path, *, version: str) -> Path:
     if source_marketplace_manifest_path.exists():
         try:
             raw_marketplace_payload = json.loads(source_marketplace_manifest_path.read_text(encoding="utf-8"))
-        except Exception:
-            raw_marketplace_payload = None
-        if isinstance(raw_marketplace_payload, dict):
-            marketplace_payload = raw_marketplace_payload
+        except Exception as exc:
+            raise SelfUpdateError(
+                f"Invalid marketplace manifest at {source_marketplace_manifest_path}: {exc}"
+            ) from exc
+        if not isinstance(raw_marketplace_payload, dict):
+            raise SelfUpdateError(
+                f"Marketplace manifest at {source_marketplace_manifest_path} must be a JSON object"
+            )
+        marketplace_payload = raw_marketplace_payload
     plugins = marketplace_payload.get("plugins")
     if not isinstance(plugins, list) or not plugins:
-        plugins = [{}]
-        marketplace_payload["plugins"] = plugins
+        raise SelfUpdateError("Marketplace manifest must include a non-empty plugins list")
     first = plugins[0]
     if not isinstance(first, dict):
-        first = {}
-        plugins[0] = first
+        raise SelfUpdateError("Marketplace plugins[0] must be an object")
     first["version"] = str(version)
     first["source"] = "./plugins/kaist-cli"
     _write_json(marketplace_manifest_path, marketplace_payload)

--- a/src/kaist_cli/core/updater.py
+++ b/src/kaist_cli/core/updater.py
@@ -578,10 +578,15 @@ def _sync_claude_plugin_metadata(install_root: Path, *, version: str) -> Path:
     if source_plugin_manifest_path.exists():
         try:
             raw_plugin_payload = json.loads(source_plugin_manifest_path.read_text(encoding="utf-8"))
-        except Exception:
-            raw_plugin_payload = None
-        if isinstance(raw_plugin_payload, dict):
-            plugin_payload = raw_plugin_payload
+        except Exception as exc:
+            raise SelfUpdateError(
+                f"Invalid plugin manifest at {source_plugin_manifest_path}: {exc}"
+            ) from exc
+        if not isinstance(raw_plugin_payload, dict):
+            raise SelfUpdateError(
+                f"Plugin manifest at {source_plugin_manifest_path} must be a JSON object"
+            )
+        plugin_payload = raw_plugin_payload
     _write_json(plugin_manifest_path, plugin_payload)
 
     marketplace_payload = {

--- a/src/kaist_cli/v2/__init__.py
+++ b/src/kaist_cli/v2/__init__.py
@@ -1,2 +1,2 @@
-"""Clean-break rewrite scaffold for kaist-cli."""
+"""KLMS implementation package for kaist-cli."""
 

--- a/src/kaist_cli/v2/klms/auth.py
+++ b/src/kaist_cli/v2/klms/auth.py
@@ -1074,11 +1074,34 @@ class AuthService:
 
     def snapshot(self) -> dict[str, Any]:
         ensure_private_dirs(self._paths)
-        config = maybe_load_config(self._paths)
+        config_error: dict[str, Any] | None = None
+        try:
+            config = maybe_load_config(self._paths)
+        except CommandError as exc:
+            # Status/probe paths must surface invalid config without raising so
+            # callers can recommend `auth login` to rewrite the file.
+            if exc.code != "CONFIG_INVALID":
+                raise
+            config = None
+            config_error = {
+                "code": exc.code,
+                "message": exc.message,
+                "hint": exc.hint,
+            }
         mode = active_auth_mode(self._paths)
         staged_auth_session = self._session_snapshot()
         cookie_stats = storage_state_cookie_stats(self._paths)
-        return {
+        recommended = self._recommended_action(
+            config=config,
+            mode=mode,
+            staged_auth_session=staged_auth_session,
+        )
+        if config_error is not None:
+            recommended = (
+                "Run `kaist klms auth login --base-url https://klms.kaist.ac.kr` "
+                "to rewrite the invalid config."
+            )
+        payload: dict[str, Any] = {
             "configured": config is not None,
             "config_path": str(self._paths.config_path),
             "profile_path": str(self._paths.profile_dir),
@@ -1100,8 +1123,11 @@ class AuthService:
                 "url_needles": list(URL_LOGIN_NEEDLES),
                 "app_login_paths": list(APP_LOGIN_PATHS),
             },
-            "recommended_action": self._recommended_action(config=config, mode=mode, staged_auth_session=staged_auth_session),
+            "recommended_action": recommended,
         }
+        if config_error is not None:
+            payload["config_error"] = config_error
+        return payload
 
     def _session_snapshot(self) -> dict[str, Any] | None:
         payload = self._load_current_auth_session()
@@ -1140,19 +1166,26 @@ class AuthService:
         return CommandResult(data=snapshot, source="bootstrap", capability="partial")
 
     def _live_check(self, *, timeout_seconds: float = 20.0) -> dict[str, Any]:
-        """Live dashboard check for ``auth status --verify``; never raises to the caller."""
+        """Live dashboard check for ``auth status --verify``; soft-fails to the caller."""
         try:
             config = maybe_load_config(self._paths)
         except CommandError as exc:
-            if exc.code == "CONFIG_INVALID":
-                return {
-                    "authenticated": None,
-                    "code": exc.code,
-                    "detail": exc.message,
-                    "note": "KLMS config is invalid; run `kaist klms auth login` to rewrite it.",
-                    "checked_at": utc_now_iso(),
-                }
-            raise
+            note = (
+                "KLMS config is invalid; run `kaist klms auth login` to rewrite it."
+                if exc.code == "CONFIG_INVALID"
+                else None
+            )
+            payload: dict[str, Any] = {
+                "authenticated": None,
+                "code": exc.code,
+                "detail": exc.message,
+                "checked_at": utc_now_iso(),
+            }
+            if note is not None:
+                payload["note"] = note
+            if exc.retryable:
+                payload["retryable"] = True
+            return payload
         if config is None:
             return {
                 "authenticated": None,
@@ -1238,7 +1271,12 @@ class AuthService:
         username: str | None = None,
         require_email_otp_strategy: bool = True,
     ) -> tuple[KlmsConfig | None, str]:
-        config = maybe_load_config(self._paths)
+        try:
+            config = maybe_load_config(self._paths)
+        except CommandError as exc:
+            if exc.code != "CONFIG_INVALID":
+                raise
+            config = None
         resolved_username = str(username or "").strip() or (config.auth_username if config else None)
         if require_email_otp_strategy and (config is None or config.auth_strategy != "email_otp"):
             raise CommandError(
@@ -1349,7 +1387,20 @@ class AuthService:
         dashboard_path: str | None = None,
         username: str | None = None,
     ) -> tuple[KlmsConfig, str]:
-        existing = maybe_load_config(self._paths)
+        try:
+            existing = maybe_load_config(self._paths)
+        except CommandError as exc:
+            # Do not rewrite via save_config defaults (easy_login); email OTP
+            # recovery must go through setup-email-otp so strategy stays correct.
+            if exc.code != "CONFIG_INVALID":
+                raise
+            raise CommandError(
+                code="CONFIG_INVALID",
+                message=exc.message,
+                hint="Run `kaist klms auth setup-email-otp --username <KAIST_ID>` to rewrite the invalid config.",
+                exit_code=40,
+                retryable=False,
+            ) from exc
         resolved_username = str(username or "").strip() or (existing.auth_username if existing else None)
         config = save_config(
             self._paths,
@@ -2617,7 +2668,13 @@ class AuthService:
         username: str | None = None,
         wait_seconds: float = EASY_LOGIN_DEFAULT_WAIT_SECONDS,
     ) -> CommandResult:
-        existing = maybe_load_config(self._paths)
+        try:
+            existing = maybe_load_config(self._paths)
+        except CommandError as exc:
+            # Corrupt config should fall through to login, which rewrites via save_config.
+            if exc.code != "CONFIG_INVALID":
+                raise
+            existing = None
         resolved_username = str(username or "").strip() or (existing.auth_username if existing else None)
         if existing is not None and existing.auth_strategy == "email_otp":
             return self.begin_refresh(

--- a/src/kaist_cli/v2/klms/auth.py
+++ b/src/kaist_cli/v2/klms/auth.py
@@ -1141,7 +1141,18 @@ class AuthService:
 
     def _live_check(self, *, timeout_seconds: float = 20.0) -> dict[str, Any]:
         """Live dashboard check for ``auth status --verify``; never raises to the caller."""
-        config = maybe_load_config(self._paths)
+        try:
+            config = maybe_load_config(self._paths)
+        except CommandError as exc:
+            if exc.code == "CONFIG_INVALID":
+                return {
+                    "authenticated": None,
+                    "code": exc.code,
+                    "detail": exc.message,
+                    "note": "KLMS config is invalid; run `kaist klms auth login` to rewrite it.",
+                    "checked_at": utc_now_iso(),
+                }
+            raise
         if config is None:
             return {
                 "authenticated": None,
@@ -1533,9 +1544,14 @@ class AuthService:
             updated["finished_at"] = utc_now_iso()
             return updated
 
-        from .auth_session import update_auth_session
+        # Best-effort side effect: persistence failure must not mask the primary
+        # auth error or prevent the worker from replying to the client.
+        try:
+            from .auth_session import update_auth_session
 
-        update_auth_session(self._paths, updater=updater)
+            update_auth_session(self._paths, updater=updater)
+        except Exception:
+            pass
 
     def _require_active_auth_session(self, session_id: str) -> dict[str, Any]:
         payload = self._load_current_auth_session()

--- a/src/kaist_cli/v2/klms/auth.py
+++ b/src/kaist_cli/v2/klms/auth.py
@@ -636,7 +636,7 @@ def _page_has_authenticated_klms_session(page: Any, *, config: KlmsConfig) -> bo
         return False
     html = _safe_page_content(page)
     if html is None:
-        return True
+        return False
     return not looks_logged_out_html(html)
 
 
@@ -696,12 +696,7 @@ def storage_state_cookie_stats(paths: KlmsPaths) -> dict[str, Any] | None:
 
 
 def record_auth_verified(paths: KlmsPaths) -> None:
-    """Persist the moment a live dashboard check last confirmed an authenticated session.
-
-    This is the honest "we know you were logged in at X" signal — written only when
-    ``_context_dashboard_state`` actually reached an authenticated dashboard, never on
-    mere file activity.
-    """
+    """Write last_verified_at after a live dashboard check confirms an authenticated session."""
     ensure_private_dirs(paths)
     try:
         paths.auth_verified_path.write_text(
@@ -1056,12 +1051,7 @@ class AuthService:
 
     @staticmethod
     def _session_expiry(cookie_stats: dict[str, Any] | None) -> dict[str, Any]:
-        """Report when the saved session expires, grounded in real cookie data.
-
-        Uses only the persisted ``MoodleSession`` cookie. When that auth cookie has
-        no absolute expiry, we say so honestly rather than using an unrelated
-        persistent cookie as a proxy; the live dashboard check remains the real gate.
-        """
+        """Report MoodleSession cookie expiry; unknown when the cookie has no absolute expiry."""
         if not isinstance(cookie_stats, dict) or "read_error" in cookie_stats:
             return {
                 "source": "unknown",
@@ -1150,12 +1140,7 @@ class AuthService:
         return CommandResult(data=snapshot, source="bootstrap", capability="partial")
 
     def _live_check(self, *, timeout_seconds: float = 20.0) -> dict[str, Any]:
-        """Confirm the saved session against a live KLMS dashboard fetch.
-
-        Returns an authenticated, unauthenticated, or unknown result rather than
-        raising, so ``auth status --verify`` always renders. A successful check also
-        refreshes ``last_verified_at`` via ``run_authenticated_with_state``.
-        """
+        """Live dashboard check for ``auth status --verify``; never raises to the caller."""
         config = maybe_load_config(self._paths)
         if config is None:
             return {
@@ -1548,12 +1533,9 @@ class AuthService:
             updated["finished_at"] = utc_now_iso()
             return updated
 
-        try:
-            from .auth_session import update_auth_session
+        from .auth_session import update_auth_session
 
-            update_auth_session(self._paths, updater=updater)
-        except Exception:
-            pass
+        update_auth_session(self._paths, updater=updater)
 
     def _require_active_auth_session(self, session_id: str) -> dict[str, Any]:
         payload = self._load_current_auth_session()

--- a/src/kaist_cli/v2/klms/capture.py
+++ b/src/kaist_cli/v2/klms/capture.py
@@ -21,12 +21,9 @@ def _utc_now_iso() -> str:
 
 
 def _same_origin(url_a: str, url_b: str) -> bool:
-    try:
-        a = urlparse(url_a)
-        b = urlparse(url_b)
-        return (a.scheme, a.netloc) == (b.scheme, b.netloc)
-    except Exception:
-        return False
+    a = urlparse(url_a)
+    b = urlparse(url_b)
+    return (a.scheme, a.netloc) == (b.scheme, b.netloc)
 
 
 def _dedupe_strings(values: list[str]) -> list[str]:
@@ -256,7 +253,6 @@ _COURSEBOARD_RUNTIME_CAPTURE_JS = r"""
     try {
       window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(events.slice(-MAX_EVENTS)));
     } catch (_error) {
-      // Ignore storage failures.
     }
   }
 
@@ -393,7 +389,6 @@ _COURSEBOARD_RUNTIME_CAPTURE_JS = r"""
           bodyPreview = preview(init.body);
         }
       } catch (_error) {
-        // Best-effort logging only.
       }
       push({
         requestId,

--- a/src/kaist_cli/v2/klms/config.py
+++ b/src/kaist_cli/v2/klms/config.py
@@ -144,7 +144,13 @@ def save_config(
     otp_source: str | None = None,
 ) -> KlmsConfig:
     ensure_private_dirs(paths)
-    existing = maybe_load_config(paths)
+    try:
+        existing = maybe_load_config(paths)
+    except CommandError as exc:
+        # Allow login/setup flows to rewrite a corrupt or invalid config in place.
+        if exc.code != "CONFIG_INVALID":
+            raise
+        existing = None
     resolved_base_url = _normalize_base_url(base_url or (existing.base_url if existing else ""))
     resolved_dashboard_path = _normalize_dashboard_path(dashboard_path or (existing.dashboard_path if existing else "/my/"))
     resolved_auth_username = (

--- a/src/kaist_cli/v2/klms/config.py
+++ b/src/kaist_cli/v2/klms/config.py
@@ -56,14 +56,14 @@ def _normalize_auth_username(value: str | None) -> str | None:
 
 def _normalize_auth_strategy(value: str | None) -> AuthStrategy:
     text = str(value or "easy_login").strip().lower() or "easy_login"
-    if text not in {"easy_login", "email_otp"}:
-        raise CommandError(
-            code="CONFIG_INVALID",
-            message=f"Unsupported auth_strategy: {value}",
-            hint="Use `easy_login` or `email_otp`.",
-            exit_code=40,
-        )
-    return text  # type: ignore[return-value]
+    if text == "easy_login" or text == "email_otp":
+        return text
+    raise CommandError(
+        code="CONFIG_INVALID",
+        message=f"Unsupported auth_strategy: {value}",
+        hint="Use `easy_login` or `email_otp`.",
+        exit_code=40,
+    )
 
 
 def _normalize_otp_source(value: str | None) -> str | None:
@@ -128,8 +128,10 @@ def load_config(paths: KlmsPaths) -> KlmsConfig:
 def maybe_load_config(paths: KlmsPaths) -> KlmsConfig | None:
     try:
         return load_config(paths)
-    except CommandError:
-        return None
+    except CommandError as exc:
+        if exc.code == "CONFIG_MISSING":
+            return None
+        raise
 
 
 def save_config(

--- a/src/kaist_cli/v2/klms/courses.py
+++ b/src/kaist_cli/v2/klms/courses.py
@@ -13,7 +13,7 @@ from .config import KlmsConfig, abs_url, load_config
 from .discovery import load_recent_courses_args
 from .models import Course
 from .paths import KlmsPaths
-from .session import build_session_bootstrap, fetch_html_batch
+from .session import KlmsSessionBootstrap, build_session_bootstrap, fetch_html_batch
 from .validate import looks_klms_error_html
 
 
@@ -212,19 +212,17 @@ def _merge_course_metadata_rows(
 
 def _load_recent_courses_from_bootstrap(
     paths: KlmsPaths,
-    bootstrap: Any,
+    bootstrap: KlmsSessionBootstrap,
     *,
     exclude_patterns: tuple[str, ...],
 ) -> list[Course]:
-    sesskey = str(getattr(bootstrap, "dashboard_sesskey", "") or "").strip()
-    http = getattr(bootstrap, "http", None)
-    config = getattr(bootstrap, "config", None)
-    if not sesskey or http is None or config is None or not hasattr(http, "post_text"):
+    sesskey = str(getattr(bootstrap, "dashboard_sesskey", None) or "").strip()
+    if not sesskey:
         return []
     try:
         args = load_recent_courses_args(paths, limit=200)
         args["limit"] = max(200, int(args.get("limit") or 0))
-        response = http.post_text(
+        response = bootstrap.http.post_text(
             f"/lib/ajax/service.php?sesskey={sesskey}&info=core_course_get_recent_courses",
             body=json.dumps([{"index": 0, "methodname": "core_course_get_recent_courses", "args": args}]),
             headers={"Content-Type": "application/json"},
@@ -232,7 +230,7 @@ def _load_recent_courses_from_bootstrap(
         )
         return _parse_recent_courses_payload(
             response.text,
-            base_url=config.base_url,
+            base_url=bootstrap.config.base_url,
             auth_mode=str(getattr(bootstrap, "auth_mode", "") or "") or None,
             exclude_patterns=exclude_patterns,
             include_all=True,
@@ -240,6 +238,8 @@ def _load_recent_courses_from_bootstrap(
             limit=None,
             course_query=None,
         )
+    except CommandError:
+        raise
     except Exception:
         return []
 

--- a/src/kaist_cli/v2/klms/courses.py
+++ b/src/kaist_cli/v2/klms/courses.py
@@ -219,6 +219,8 @@ def _load_recent_courses_from_bootstrap(
     sesskey = str(getattr(bootstrap, "dashboard_sesskey", None) or "").strip()
     if not sesskey:
         return []
+    # Soft enrichment only: callers merge with dashboard metadata and must keep
+    # working when the recent-courses AJAX path is unavailable or shape-changed.
     try:
         args = load_recent_courses_args(paths, limit=200)
         args["limit"] = max(200, int(args.get("limit") or 0))
@@ -238,8 +240,6 @@ def _load_recent_courses_from_bootstrap(
             limit=None,
             course_query=None,
         )
-    except CommandError:
-        raise
     except Exception:
         return []
 

--- a/src/kaist_cli/v2/klms/files.py
+++ b/src/kaist_cli/v2/klms/files.py
@@ -968,10 +968,6 @@ class FileService:
         if_exists: str,
         auth_mode: str,
     ) -> dict[str, Any]:
-        """Download prepared file items and retain their generic pull outcomes.
-
-        Callers own candidate discovery and any surface-specific result decoration.
-        """
         candidate_course_ids = {str(item.course_id).strip() for item in items if str(item.course_id or "").strip()}
         include_course_dirs = len(candidate_course_ids) != 1
         base_root = _resolve_destination_root(files_root=self._paths.files_root, subdir=subdir, dest=dest)

--- a/src/kaist_cli/v2/klms/probe.py
+++ b/src/kaist_cli/v2/klms/probe.py
@@ -8,7 +8,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 from urllib.request import Request, build_opener, HTTPRedirectHandler
 
-from ..contracts import CommandResult
+from ..contracts import CommandError, CommandResult
 from .auth import APP_LOGIN_PATHS, AuthService, extract_sesskey, looks_logged_out_html, looks_login_url
 from .config import abs_url, maybe_load_config
 from .discovery import load_json_summary, load_recent_courses_args
@@ -361,7 +361,13 @@ class CapabilityProbeService:
 
     def probe(self, *, live: bool = False, timeout_seconds: float = 10.0) -> CommandResult:
         auth_snapshot = self._auth.snapshot()
-        config = maybe_load_config(self._paths)
+        try:
+            config = maybe_load_config(self._paths)
+        except CommandError as exc:
+            # Probe already soft-handles missing config; treat invalid the same.
+            if exc.code != "CONFIG_INVALID":
+                raise
+            config = None
         api_map = load_json_summary(str(self._paths.api_map_path))
         endpoint_discovery = load_json_summary(str(self._paths.endpoint_discovery_path))
 

--- a/src/kaist_cli/v2/klms/request.py
+++ b/src/kaist_cli/v2/klms/request.py
@@ -111,7 +111,7 @@ class RequestService:
                     payload["json_parse_ok"] = True
                 except Exception as exc:  # noqa: BLE001
                     payload["json_parse_ok"] = False
-                    payload["json_parse_error"] = str(exc)
+                    payload["parse_error"] = str(exc)
             return CommandResult(data=payload, source="browser", capability="full")
 
         return self._auth.run_authenticated(

--- a/src/kaist_cli/v2/klms/request.py
+++ b/src/kaist_cli/v2/klms/request.py
@@ -108,8 +108,10 @@ class RequestService:
             if content_type and "json" in content_type.lower():
                 try:
                     payload["body_json"] = json.loads(body_text)
-                except Exception:
-                    pass
+                    payload["json_parse_ok"] = True
+                except Exception as exc:  # noqa: BLE001
+                    payload["json_parse_ok"] = False
+                    payload["json_parse_error"] = str(exc)
             return CommandResult(data=payload, source="browser", capability="full")
 
         return self._auth.run_authenticated(

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -705,6 +705,34 @@ def test_sync_claude_plugin_metadata_rejects_corrupt_manifests(tmp_path: Path) -
     with pytest.raises(updater.SelfUpdateError, match="non-empty plugins list"):
         updater._sync_claude_plugin_metadata(install_root, version="0.5.3")  # type: ignore[attr-defined]
 
+    (skill_root / "plugin.json").write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+    (skill_root / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "kaist-cli",
+                "owner": {"name": "kaist-cli"},
+                "plugins": [{"name": "kaist-cli", "source": "."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(updater.SelfUpdateError, match="must be a JSON object"):
+        updater._sync_claude_plugin_metadata(install_root, version="0.5.3")  # type: ignore[attr-defined]
+
+    (skill_root / "plugin.json").write_text(json.dumps({"name": "kaist-cli"}), encoding="utf-8")
+    (skill_root / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "kaist-cli",
+                "owner": {"name": "kaist-cli"},
+                "plugins": ["not-an-object"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(updater.SelfUpdateError, match="plugins\\[0\\] must be an object"):
+        updater._sync_claude_plugin_metadata(install_root, version="0.5.3")  # type: ignore[attr-defined]
+
 
 def test_install_script_detects_linux_glibc_target(tmp_path: Path) -> None:
     downloads_dir = tmp_path / "downloads"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -673,6 +673,39 @@ def test_distribution_discovers_managed_onedir_bundle(tmp_path: Path) -> None:
     assert info.manifest.binary_relpath == "bin/kaist/kaist"
 
 
+def test_sync_claude_plugin_metadata_rejects_corrupt_manifests(tmp_path: Path) -> None:
+    install_root = tmp_path / "install-root"
+    skill_root = install_root / "current" / "skills" / "kaist-cli" / ".claude-plugin"
+    skill_root.mkdir(parents=True)
+    (install_root / "current" / "skills" / "kaist-cli" / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+
+    (skill_root / "plugin.json").write_text("{not-json", encoding="utf-8")
+    (skill_root / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "kaist-cli",
+                "owner": {"name": "kaist-cli"},
+                "plugins": [{"name": "kaist-cli", "source": "."}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(updater.SelfUpdateError, match="Invalid plugin manifest"):
+        updater._sync_claude_plugin_metadata(install_root, version="0.5.3")  # type: ignore[attr-defined]
+
+    (skill_root / "plugin.json").write_text(json.dumps({"name": "kaist-cli"}), encoding="utf-8")
+    (skill_root / "marketplace.json").write_text("{not-json", encoding="utf-8")
+    with pytest.raises(updater.SelfUpdateError, match="Invalid marketplace manifest"):
+        updater._sync_claude_plugin_metadata(install_root, version="0.5.3")  # type: ignore[attr-defined]
+
+    (skill_root / "marketplace.json").write_text(
+        json.dumps({"name": "kaist-cli", "owner": {"name": "kaist-cli"}, "plugins": []}),
+        encoding="utf-8",
+    )
+    with pytest.raises(updater.SelfUpdateError, match="non-empty plugins list"):
+        updater._sync_claude_plugin_metadata(install_root, version="0.5.3")  # type: ignore[attr-defined]
+
+
 def test_install_script_detects_linux_glibc_target(tmp_path: Path) -> None:
     downloads_dir = tmp_path / "downloads"
     _prepare_release_dir(downloads_dir, "v0.1.4", target="linux-x86_64-gnu", bundle_mode="onedir")

--- a/tests/test_v2_cli.py
+++ b/tests/test_v2_cli.py
@@ -5495,7 +5495,7 @@ def test_live_check_reports_invalid_config_as_unknown(tmp_path: Path) -> None:
     os.environ["KAIST_CLI_HOME"] = str(monkey_home)
     try:
         auth = AuthService(resolve_paths())
-        result = auth._live_check()
+        result = auth.status(verify=True).data["live_check"]
     finally:
         if old_home is None:
             os.environ.pop("KAIST_CLI_HOME", None)
@@ -5594,5 +5594,95 @@ def test_request_get_surfaces_json_parse_failure(tmp_path: Path) -> None:
             os.environ["KAIST_CLI_HOME"] = old_home
 
     assert result.data["json_parse_ok"] is False
-    assert "json_parse_error" in result.data
+    assert "parse_error" in result.data
     assert "body_json" not in result.data
+
+
+def test_auth_status_surfaces_invalid_config_without_raising(tmp_path: Path) -> None:
+    monkey_home = tmp_path / "kaist-home"
+    config_path = monkey_home / "private" / "klms" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        'base_url = "https://klms.kaist.ac.kr"\nauth_strategy = "bogus"\n',
+        encoding="utf-8",
+    )
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(monkey_home)
+    try:
+        auth = AuthService(resolve_paths())
+        offline = auth.status(verify=False).data
+        verified = auth.status(verify=True).data
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+
+    assert offline["configured"] is False
+    assert offline["config"] is None
+    assert offline["config_error"]["code"] == "CONFIG_INVALID"
+    assert "rewrite the invalid config" in offline["recommended_action"]
+
+    live_check = verified["live_check"]
+    assert live_check["authenticated"] is None
+    assert live_check["code"] == "CONFIG_INVALID"
+    assert verified["config_error"]["code"] == "CONFIG_INVALID"
+
+
+def test_auth_refresh_rewrites_invalid_config_via_login(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkey_home = tmp_path / "kaist-home"
+    config_path = monkey_home / "private" / "klms" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("this is not valid toml [[[", encoding="utf-8")
+    monkeypatch.setenv("KAIST_CLI_HOME", str(monkey_home))
+    auth = AuthService(resolve_paths())
+
+    def fake_login(**kwargs):  # type: ignore[no-untyped-def]
+        saved = save_config(
+            auth._paths,
+            base_url=kwargs.get("base_url") or "https://klms.kaist.ac.kr",
+            dashboard_path=kwargs.get("dashboard_path"),
+            auth_username=kwargs.get("username") or "student123",
+        )
+        return CommandResult(
+            data={"ok": True, "auth_username": saved.auth_username, "auth_strategy": saved.auth_strategy},
+            source="bootstrap",
+            capability="partial",
+        )
+
+    monkeypatch.setattr(auth, "login", fake_login)
+    result = auth.refresh(base_url="https://klms.kaist.ac.kr", username="student123")
+    reloaded = load_config(auth._paths)
+    assert result.data["ok"] is True
+    assert reloaded.auth_username == "student123"
+    assert reloaded.auth_strategy == "easy_login"
+
+
+def test_require_email_otp_config_raises_clearly_on_invalid_config(tmp_path: Path) -> None:
+    monkey_home = tmp_path / "kaist-home"
+    config_path = monkey_home / "private" / "klms" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    corrupt = 'base_url = "https://klms.kaist.ac.kr"\nauth_strategy = "bogus"\n'
+    config_path.write_text(corrupt, encoding="utf-8")
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(monkey_home)
+    try:
+        auth = AuthService(resolve_paths())
+        with pytest.raises(CommandError) as exc_info:
+            auth._require_email_otp_config(
+                base_url="https://klms.kaist.ac.kr",
+                username="student123",
+            )
+        # Must not demote corrupt email-OTP configs to easy_login via save_config defaults.
+        assert config_path.read_text(encoding="utf-8") == corrupt
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+
+    assert exc_info.value.code == "CONFIG_INVALID"
+    assert "setup-email-otp" in (exc_info.value.hint or "")

--- a/tests/test_v2_cli.py
+++ b/tests/test_v2_cli.py
@@ -214,8 +214,7 @@ def test_auth_status_detects_storage_state_and_cookie_stats(tmp_path: Path) -> N
 
 
 def test_auth_status_session_expiry_unknown_without_cookie_expiry(tmp_path: Path) -> None:
-    # A bare MoodleSession session cookie carries no absolute expiry; status must say
-    # so honestly rather than inventing a fixed refresh window.
+    # Bare MoodleSession with expires=-1 has no absolute expiry; status source stays unknown.
     _write_config(tmp_path)
     storage_state_path = tmp_path / "kaist-home" / "private" / "klms" / "storage_state.json"
     storage_state_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_v2_cli.py
+++ b/tests/test_v2_cli.py
@@ -29,9 +29,9 @@ from kaist_cli.v2.klms.auth_session import clear_auth_session, load_auth_session
 from kaist_cli.v2.klms.auth import AuthService
 from kaist_cli.v2.klms.auth import _EasyLoginSignals, _extract_easy_login_error_message, _extract_easy_login_number, _extract_sso_login_view_url, _request_email_otp_delivery, _should_update_easy_login_number, _submit_password_login, looks_login_url
 from kaist_cli.v2.klms.assignments import AssignmentService, _extract_assignment_detail_from_html, _extract_assignment_rows_from_calendar_data, _filter_assignments
-from kaist_cli.v2.klms.courses import CourseService, _course_is_current_term, _course_matches_query, _course_metadata_map, _discover_courses_from_dashboard, _parse_recent_courses_payload
+from kaist_cli.v2.klms.courses import CourseService, _course_is_current_term, _course_matches_query, _course_metadata_map, _discover_courses_from_dashboard, _load_recent_courses_from_bootstrap, _parse_recent_courses_payload
 from kaist_cli.v2.klms.capture import _courseboard_runtime_capture_summary, _extract_courseboard_js_hints
-from kaist_cli.v2.klms.config import load_config
+from kaist_cli.v2.klms.config import KlmsConfig, load_config, maybe_load_config, save_config
 from kaist_cli.v2.klms.dashboard import DashboardService, _build_inbox_items, _decorate_today_assignments, _filter_inbox_assignments, _filter_inbox_files, _select_materials, _select_recent_notices
 from kaist_cli.v2.klms.discovery import load_recent_courses_args, map_discovery_report
 from kaist_cli.v2.klms.files import FileService, _extract_file_items_from_course_contents, _extract_file_items_from_html, _normalize_file_item_metadata, _pull_subdir_for_item, _sanitize_relpath, _synthesize_file_item_from_url, _unwrap_moodle_ajax_payload
@@ -41,7 +41,7 @@ from kaist_cli.v2.klms.notices import NoticeService, _discover_notice_board_ids_
 from kaist_cli.v2.klms.paths import resolve_paths
 from kaist_cli.v2.klms.provider_state import ProviderLoad
 from kaist_cli.v2.klms.request import RequestService
-from kaist_cli.v2.klms.session import KlmsDownloadFallback
+from kaist_cli.v2.klms.session import KlmsDownloadFallback, KlmsHttpResponse, KlmsSessionBootstrap
 from kaist_cli.v2.klms.videos import VideoService, _extract_video_items_from_html, _parse_video_detail_from_html, _parse_video_viewer_from_html
 
 
@@ -5423,3 +5423,176 @@ def test_sync_run_requires_auth_artifact(tmp_path: Path) -> None:
     payload = json.loads(cp.stdout)
     assert payload["ok"] is False
     assert payload["error"]["code"] == "AUTH_MISSING"
+
+
+def test_page_has_authenticated_session_false_when_content_unreadable() -> None:
+    config = KlmsConfig(
+        base_url="https://klms.kaist.ac.kr",
+        dashboard_path="/my/",
+        auth_username=None,
+        auth_strategy="easy_login",
+        otp_source=None,
+        course_ids=(),
+        notice_board_ids=(),
+        exclude_course_title_patterns=(),
+    )
+
+    class BrokenPage:
+        url = "https://klms.kaist.ac.kr/my/"
+
+        def content(self) -> str:
+            raise RuntimeError("page closed")
+
+    assert auth_module._page_has_authenticated_klms_session(BrokenPage(), config=config) is False
+
+
+def test_maybe_load_config_raises_on_invalid_config(tmp_path: Path) -> None:
+    monkey_home = tmp_path / "kaist-home"
+    config_path = monkey_home / "private" / "klms" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('base_url = "https://klms.kaist.ac.kr"\nauth_strategy = "not-a-strategy"\n', encoding="utf-8")
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(monkey_home)
+    try:
+        paths = resolve_paths()
+        with pytest.raises(CommandError) as exc_info:
+            maybe_load_config(paths)
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+    assert exc_info.value.code == "CONFIG_INVALID"
+
+
+def test_save_config_rewrites_invalid_existing_config(tmp_path: Path) -> None:
+    monkey_home = tmp_path / "kaist-home"
+    config_path = monkey_home / "private" / "klms" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("this is not valid toml [[[", encoding="utf-8")
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(monkey_home)
+    try:
+        paths = resolve_paths()
+        saved = save_config(paths, base_url="https://klms.kaist.ac.kr", auth_username="student123")
+        reloaded = load_config(paths)
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+    assert saved.base_url == "https://klms.kaist.ac.kr"
+    assert reloaded.auth_username == "student123"
+    assert reloaded.auth_strategy == "easy_login"
+
+
+def test_live_check_reports_invalid_config_as_unknown(tmp_path: Path) -> None:
+    monkey_home = tmp_path / "kaist-home"
+    config_path = monkey_home / "private" / "klms" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text('base_url = "https://klms.kaist.ac.kr"\nauth_strategy = "bogus"\n', encoding="utf-8")
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(monkey_home)
+    try:
+        auth = AuthService(resolve_paths())
+        result = auth._live_check()
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+    assert result["authenticated"] is None
+    assert result["code"] == "CONFIG_INVALID"
+
+
+def test_load_recent_courses_from_bootstrap_soft_fails_on_command_error(tmp_path: Path) -> None:
+    class BoomHttp:
+        def post_text(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return KlmsHttpResponse(url="https://klms.kaist.ac.kr/x", text="not-json", via="http")
+
+    config = KlmsConfig(
+        base_url="https://klms.kaist.ac.kr",
+        dashboard_path="/my/",
+        auth_username=None,
+        auth_strategy="easy_login",
+        otp_source=None,
+        course_ids=(),
+        notice_board_ids=(),
+        exclude_course_title_patterns=(),
+    )
+    bootstrap = KlmsSessionBootstrap(
+        config=config,
+        auth_mode="storage_state",
+        dashboard_url="https://klms.kaist.ac.kr/my/",
+        dashboard_html="<html></html>",
+        dashboard_sesskey="abc123",
+        http=BoomHttp(),  # type: ignore[arg-type]
+    )
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(tmp_path / "kaist-home")
+    try:
+        paths = resolve_paths()
+        courses = _load_recent_courses_from_bootstrap(paths, bootstrap, exclude_patterns=())
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+    assert courses == []
+
+
+def test_persist_worker_failure_swallows_persistence_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KAIST_CLI_HOME", str(tmp_path / "kaist-home"))
+    _write_config(tmp_path)
+    auth = AuthService(resolve_paths())
+
+    def boom_update_auth_session(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("disk full")
+
+    monkeypatch.setattr("kaist_cli.v2.klms.auth_session.update_auth_session", boom_update_auth_session)
+    auth._persist_worker_failure(
+        "sess-1",
+        CommandError(code="AUTH_FAILED", message="otp rejected", exit_code=10),
+    )
+
+
+def test_request_get_surfaces_json_parse_failure(tmp_path: Path) -> None:
+    class FakePage:
+        url = "https://klms.kaist.ac.kr/lib/ajax/service.php"
+
+        def evaluate(self, script: str, payload: dict[str, str]) -> dict[str, object]:
+            return {
+                "ok": True,
+                "status": 200,
+                "url": payload["url"],
+                "contentType": "application/json",
+                "text": "{not-json",
+            }
+
+        def close(self) -> None:
+            return None
+
+    class FakeContext:
+        def new_page(self) -> FakePage:
+            return FakePage()
+
+    class FakeAuth:
+        def run_authenticated(self, *, config, headless, accept_downloads, timeout_seconds, callback):  # type: ignore[no-untyped-def]
+            return callback(FakeContext(), "storage_state")
+
+    _write_config(tmp_path)
+    old_home = os.environ.get("KAIST_CLI_HOME")
+    os.environ["KAIST_CLI_HOME"] = str(tmp_path / "kaist-home")
+    try:
+        paths = resolve_paths()
+        service = RequestService(paths, FakeAuth())  # type: ignore[arg-type]
+        result = service.get("/lib/ajax/service.php")
+    finally:
+        if old_home is None:
+            os.environ.pop("KAIST_CLI_HOME", None)
+        else:
+            os.environ["KAIST_CLI_HOME"] = old_home
+
+    assert result.data["json_parse_ok"] is False
+    assert "json_parse_error" in result.data
+    assert "body_json" not in result.data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First of six PRs removing AI code slop. This PR focuses on **correctness**: stop hiding failures behind defensive try/except and type lies — without turning intentional soft-fail paths into hard failures.

### Changes
- **Auth:** unreadable page HTML is no longer treated as authenticated; OTP worker failure persistence is best-effort again (must not mask the primary error); `_live_check` / `status --verify` soft-report invalid config; trim apologetic docstrings
- **Config:** remove `# type: ignore[return-value]`; `maybe_load_config` only swallows `CONFIG_MISSING`; `save_config` rewrites corrupt/invalid configs so login/setup can recover
- **Invalid-config callers (review fix):** `snapshot`/`status`/`probe` soft-surface `config_error`; `refresh` recovers via `login`; email-OTP require path raises with `setup-email-otp` hint (does not demote to `easy_login`)
- **Courses:** type bootstrap as `KlmsSessionBootstrap`; recent-courses enrichment soft-fails (`[]`) so notices/files/videos keep working on AJAX shape errors
- **Request:** surface `json_parse_ok` / `parse_error` when Content-Type claims JSON
- **Updater:** refuse inventing empty marketplace/plugin manifests on corrupt JSON; reject non-object plugin/marketplace payloads
- **Capture:** remove dead `urlparse` try/except; drop filler JS comments
- Trim tutorial/scaffold docstrings in runtime, state_store, `v2/__init__`

### Review notes
Deep review found `maybe_load_config` was made strict while `snapshot`/`status`/`refresh`/`probe` still assumed the old swallow-everything contract. Fixed on this branch before merge.

### Test plan
- [x] Full `pytest` suite (251 passed)
- [x] Unreadable `page.content()` → not authenticated
- [x] Invalid config → `maybe_load_config` raises; `save_config` rewrites; `status(verify=True)` soft-reports
- [x] `refresh` on corrupt config → recovers via login rewrite
- [x] `_require_email_otp_config` on invalid config → `CONFIG_INVALID` + setup-email-otp hint (no silent demotion)
- [x] Recent-courses `CommandError` → enrichment returns `[]`
- [x] Worker persist IO failure → does not raise
- [x] JSON body parse fail → `json_parse_ok=false` + `parse_error`
- [x] Corrupt / non-object plugin/marketplace manifests → `SelfUpdateError`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c401e5bd-d26e-43d7-beda-a79c61428cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c401e5bd-d26e-43d7-beda-a79c61428cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

