### PR TITLE
Extract shared Moodle/HTML/time helpers (PR2/6)

### DIFF
--- a/src/kaist_cli/cli/help_format.py
+++ b/src/kaist_cli/cli/help_format.py
@@ -1,12 +1,7 @@
+"""Compatibility re-export; prefer ``kaist_cli.core.help_format``."""
+
 from __future__ import annotations
 
-import argparse
-import textwrap
+from ..core.help_format import HelpFormatter, dedent
 
-
-class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    pass
-
-
-def dedent(text: str) -> str:
-    return textwrap.dedent(text).strip()
+__all__ = ["HelpFormatter", "dedent"]

--- a/src/kaist_cli/cli/help_format.py
+++ b/src/kaist_cli/cli/help_format.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import argparse
+import textwrap
+
+
+class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+def dedent(text: str) -> str:
+    return textwrap.dedent(text).strip()

--- a/src/kaist_cli/cli/parser.py
+++ b/src/kaist_cli/cli/parser.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
 import argparse
-import textwrap
 
 from ..core.distribution import discover_distribution_info
 from ..core.system_registry import default_registry
-
-
-class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    pass
-
-
-def _dedent(text: str) -> str:
-    return textwrap.dedent(text).strip()
+from .help_format import HelpFormatter, dedent as _dedent
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/kaist_cli/cli/parser.py
+++ b/src/kaist_cli/cli/parser.py
@@ -4,7 +4,7 @@ import argparse
 
 from ..core.distribution import discover_distribution_info
 from ..core.system_registry import default_registry
-from .help_format import HelpFormatter, dedent as _dedent
+from ..core.help_format import HelpFormatter, dedent as _dedent
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/kaist_cli/core/agents.py
+++ b/src/kaist_cli/core/agents.py
@@ -4,6 +4,8 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+
+from .fsutil import remove_path
 from typing import Any
 
 from .distribution import SKILL_NAME, discover_distribution_info
@@ -77,12 +79,6 @@ def resolve_agent_install_spec(agent: str, *, custom_path: str | None = None) ->
     raise AgentCommandError("CONFIG_INVALID", 40, False, f"Unsupported agent target: {agent}", None)
 
 
-def _remove_path(path: Path) -> None:
-    if path.is_symlink() or path.is_file():
-        path.unlink()
-        return
-    if path.is_dir():
-        shutil.rmtree(path)
 
 
 def _status_entry(spec: AgentInstallSpec, *, bundled_skill_path: Path) -> dict[str, Any]:
@@ -137,7 +133,7 @@ def _install_target(spec: AgentInstallSpec, *, copy: bool, force: bool) -> dict[
                 f"Target path already exists: {path}",
                 "Re-run with --force to replace it.",
             )
-        _remove_path(path)
+        remove_path(path)
 
     path.parent.mkdir(parents=True, exist_ok=True)
     if copy:
@@ -159,7 +155,7 @@ def _uninstall_target(spec: AgentInstallSpec) -> dict[str, Any]:
     existed = path.exists() or path.is_symlink()
     previous = _status_entry(spec, bundled_skill_path=bundled_skill_path)
     if existed:
-        _remove_path(path)
+        remove_path(path)
     return {
         **previous,
         "action": "removed" if existed else "noop",

--- a/src/kaist_cli/core/envelope.py
+++ b/src/kaist_cli/core/envelope.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
 from typing import Any
 
-
-def utc_now_iso() -> str:
-    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+from .timeutil import utc_now_iso
 
 
 def _sanitize_schema_part(value: str | None) -> str:

--- a/src/kaist_cli/core/fsutil.py
+++ b/src/kaist_cli/core/fsutil.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+        return
+    if path.is_dir():
+        shutil.rmtree(path)

--- a/src/kaist_cli/core/help_format.py
+++ b/src/kaist_cli/core/help_format.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import argparse
+import textwrap
+
+
+class HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+    pass
+
+
+def dedent(text: str) -> str:
+    return textwrap.dedent(text).strip()

--- a/src/kaist_cli/core/timeutil.py
+++ b/src/kaist_cli/core/timeutil.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def iso_from_epoch_seconds(value: float | int | None) -> str | None:
+    if not isinstance(value, (int, float)):
+        return None
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def cache_is_fresh_enough(entry: dict[str, Any] | None, *, max_age_seconds: int = 3600) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    age_seconds = entry.get("age_seconds")
+    if isinstance(age_seconds, (int, float)):
+        return float(age_seconds) <= float(max_age_seconds)
+    stored_at = entry.get("stored_at")
+    if isinstance(stored_at, (int, float)):
+        return (datetime.now(timezone.utc).timestamp() - float(stored_at)) <= float(max_age_seconds)
+    return False

--- a/src/kaist_cli/core/updater.py
+++ b/src/kaist_cli/core/updater.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from .distribution import BundleManifest, DistributionInfo, RELEASE_REPO, discover_distribution_info, load_bundle_manifest
+from .fsutil import remove_path
 from .versioning import version_string
 
 
@@ -505,12 +506,6 @@ def _swap_symlink(link_path: Path, target_path: Path) -> None:
     os.replace(tmp_path, link_path)
 
 
-def _remove_path(path: Path) -> None:
-    if path.is_symlink() or path.is_file():
-        path.unlink()
-        return
-    if path.is_dir():
-        shutil.rmtree(path)
 
 
 def _prune_versions(ctx: ManagedInstallContext, keep_roots: set[Path]) -> list[str]:
@@ -567,7 +562,7 @@ def _sync_claude_plugin_metadata(install_root: Path, *, version: str) -> Path:
     plugin_root.mkdir(parents=True, exist_ok=True)
     skill_link.parent.mkdir(parents=True, exist_ok=True)
     if skill_link.exists() or skill_link.is_symlink():
-        _remove_path(skill_link)
+        remove_path(skill_link)
     skill_link.symlink_to(skill_target, target_is_directory=True)
 
     plugin_payload = {
@@ -705,9 +700,9 @@ def perform_self_update() -> dict[str, Any]:
             )
 
         if temp_version_dir.exists() or temp_version_dir.is_symlink():
-            _remove_path(temp_version_dir)
+            remove_path(temp_version_dir)
         if version_dir.exists() or version_dir.is_symlink():
-            _remove_path(version_dir)
+            remove_path(version_dir)
 
         _progress("Extracting update bundle...")
         manifest = _extract_bundle_root(archive_path, temp_version_dir)
@@ -719,7 +714,7 @@ def perform_self_update() -> dict[str, Any]:
     if previous_root is not None and previous_root != version_dir.resolve():
         _swap_symlink(ctx.previous_link, previous_root)
     elif ctx.previous_link.exists() or ctx.previous_link.is_symlink():
-        _remove_path(ctx.previous_link)
+        remove_path(ctx.previous_link)
 
     keep_roots = {version_dir}
     previous_kept = _resolved_symlink(ctx.previous_link)

--- a/src/kaist_cli/systems/klms/adapter.py
+++ b/src/kaist_cli/systems/klms/adapter.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
 import argparse
-import textwrap
 
+from ...cli.help_format import HelpFormatter as _HelpFormatter
+from ...cli.help_format import dedent as _dedent
 from ...core.contracts import SystemAdapter
 from ...v2.parser import register_klms_parser
-
-
-class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    pass
-
-
-def _dedent(text: str) -> str:
-    return textwrap.dedent(text).strip()
 
 
 class KlmsAdapter(SystemAdapter):

--- a/src/kaist_cli/systems/klms/adapter.py
+++ b/src/kaist_cli/systems/klms/adapter.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import argparse
 
-from ...cli.help_format import HelpFormatter as _HelpFormatter
-from ...cli.help_format import dedent as _dedent
+from ...core.help_format import HelpFormatter as _HelpFormatter
+from ...core.help_format import dedent as _dedent
 from ...core.contracts import SystemAdapter
 from ...v2.parser import register_klms_parser
 

--- a/src/kaist_cli/systems/portal/adapter.py
+++ b/src/kaist_cli/systems/portal/adapter.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from ...cli.help_format import HelpFormatter as _HelpFormatter
-from ...cli.help_format import dedent as _dedent
+from ...core.help_format import HelpFormatter as _HelpFormatter
+from ...core.help_format import dedent as _dedent
 from ...core.contracts import SystemAdapter
 from . import auth, services
 

--- a/src/kaist_cli/systems/portal/adapter.py
+++ b/src/kaist_cli/systems/portal/adapter.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import textwrap
 from typing import Any
 
+from ...cli.help_format import HelpFormatter as _HelpFormatter
+from ...cli.help_format import dedent as _dedent
 from ...core.contracts import SystemAdapter
 from . import auth, services
-
-
-class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    pass
-
-
-def _dedent(text: str) -> str:
-    return textwrap.dedent(text).strip()
 
 
 class PortalAdapter(SystemAdapter):

--- a/src/kaist_cli/systems/update/adapter.py
+++ b/src/kaist_cli/systems/update/adapter.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import textwrap
 from typing import Any
 
+from ...cli.help_format import HelpFormatter as _HelpFormatter
+from ...cli.help_format import dedent as _dedent
 from ...core.contracts import SystemAdapter
 from ...core.updater import check_for_update, perform_self_update
-
-
-class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    pass
-
-
-def _dedent(text: str) -> str:
-    return textwrap.dedent(text).strip()
 
 
 class UpdateAdapter(SystemAdapter):

--- a/src/kaist_cli/systems/update/adapter.py
+++ b/src/kaist_cli/systems/update/adapter.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from ...cli.help_format import HelpFormatter as _HelpFormatter
-from ...cli.help_format import dedent as _dedent
+from ...core.help_format import HelpFormatter as _HelpFormatter
+from ...core.help_format import dedent as _dedent
 from ...core.contracts import SystemAdapter
 from ...core.updater import check_for_update, perform_self_update
 

--- a/src/kaist_cli/v2/envelope.py
+++ b/src/kaist_cli/v2/envelope.py
@@ -2,14 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timezone
 from typing import Any
 
+from ..core.timeutil import utc_now_iso
 from .contracts import CommandError, CommandResult
-
-
-def utc_now_iso() -> str:
-    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def success_envelope(args: argparse.Namespace, result: CommandResult) -> dict[str, Any]:

--- a/src/kaist_cli/v2/klms/assignments.py
+++ b/src/kaist_cli/v2/klms/assignments.py
@@ -10,6 +10,8 @@ from typing import Any
 from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
+from ...core.timeutil import iso_from_epoch_seconds as _iso_from_epoch, utc_now_iso as _iso_now_utc
+from .moodle_html import extend_dict_candidates, table_col_index, unwrap_moodle_ajax_data as _unwrap_moodle_ajax_data
 from .auth import AuthService, extract_sesskey, looks_logged_out_html, looks_login_url
 from .config import KlmsConfig, abs_url, load_config
 from .courses import (
@@ -73,19 +75,6 @@ def _parse_datetime_guess(raw: str) -> str | None:
         except ValueError:
             continue
     return None
-
-
-def _iso_from_epoch(epoch: float | int | None) -> str | None:
-    if not isinstance(epoch, (int, float)):
-        return None
-    try:
-        return datetime.fromtimestamp(float(epoch), tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-    except Exception:
-        return None
-
-
-def _iso_now_utc() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _epoch_from_iso(value: str | None) -> float | None:
@@ -198,18 +187,12 @@ def _extract_assignment_rows_from_calendar_data(
 ) -> list[Assignment]:
     candidates: list[dict[str, Any]] = []
 
-    def push_list(items: Any) -> None:
-        if isinstance(items, list):
-            for item in items:
-                if isinstance(item, dict):
-                    candidates.append(item)
-
     if isinstance(data, dict):
-        push_list(data.get("events"))
-        push_list(data.get("data"))
-        push_list(data.get("items"))
+        extend_dict_candidates(candidates, data.get("events"))
+        extend_dict_candidates(candidates, data.get("data"))
+        extend_dict_candidates(candidates, data.get("items"))
     elif isinstance(data, list):
-        push_list(data)
+        extend_dict_candidates(candidates, data)
 
     assignments: list[Assignment] = []
     for row in candidates:
@@ -366,15 +349,8 @@ def _extract_assignments_from_index_html(
     headers, table = found
     headers_norm = [header.lower() for header in headers]
 
-    def col_index(*needles: str) -> int | None:
-        for needle in needles:
-            for index, header in enumerate(headers_norm):
-                if needle in header:
-                    return index
-        return None
-
-    name_i = col_index("assignment", "과제", "과제명", "name", "제목") or 0
-    due_i = col_index("due", "마감", "기한", "종료")
+    name_i = table_col_index(headers_norm, "assignment", "과제", "과제명", "name", "제목") or 0
+    due_i = table_col_index(headers_norm, "due", "마감", "기한", "종료")
     rows = table.find_all("tr")
     if rows and rows[0].find_all("th"):
         rows = rows[1:]
@@ -814,7 +790,7 @@ class AssignmentService:
                         response_text = str(result or "")
                     finally:
                         page.close()
-                data = self._unwrap_moodle_ajax_data(response_text)
+                data = _unwrap_moodle_ajax_data(response_text)
                 if data is None:
                     continue
                 assignments = _extract_assignment_rows_from_calendar_data(
@@ -901,18 +877,6 @@ class AssignmentService:
             include_past=include_past,
         )
 
-    @staticmethod
-    def _unwrap_moodle_ajax_data(text: str) -> Any | None:
-        try:
-            payload = json.loads(text)
-        except Exception:
-            return None
-        if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
-            return None
-        first = payload[0]
-        if bool(first.get("error")):
-            return None
-        return first.get("data")
 
 
 def _looks_like_attachment_url(url: str) -> bool:

--- a/src/kaist_cli/v2/klms/auth_session.py
+++ b/src/kaist_cli/v2/klms/auth_session.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 from ...core.state_store import read_json_file, update_json_file, write_json_file_atomic
+from ...core.timeutil import utc_now_iso
 from .paths import KlmsPaths
 
 AUTH_SESSION_VERSION = 1
@@ -17,10 +18,6 @@ def _default_session_payload() -> dict[str, Any]:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc).replace(microsecond=0)
-
-
-def utc_now_iso() -> str:
-    return _utc_now().isoformat().replace("+00:00", "Z")
 
 
 def session_expiry_iso(*, ttl_seconds: float) -> str:

--- a/src/kaist_cli/v2/klms/capture.py
+++ b/src/kaist_cli/v2/klms/capture.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlparse
@@ -10,14 +9,16 @@ from urllib.parse import quote, urlparse
 from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandResult
+from ...core.timeutil import utc_now_iso as _utc_now_iso
 from .auth import AuthService, extract_sesskey
 from .config import KlmsConfig, abs_url, load_config
 from .discovery import map_discovery_report, summarize_json_shape
+from .moodle_html import (
+    discover_notice_board_ids_from_course_page as _discover_notice_board_ids_from_course_page,
+    extend_dict_candidates,
+    unwrap_moodle_ajax_data as _unwrap_moodle_ajax_data,
+)
 from .paths import KlmsPaths, chmod_best_effort, ensure_private_dirs
-
-
-def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _same_origin(url_a: str, url_b: str) -> bool:
@@ -42,43 +43,6 @@ def _extract_course_ids_from_dashboard(html: str, *, configured_ids: tuple[str, 
     out: list[str] = [str(course_id).strip() for course_id in configured_ids if str(course_id).strip()]
     out.extend(re.findall(r"/course/view\.php\?id=(\d+)", html))
     return _dedupe_strings(out)[: max(0, limit)]
-
-
-def _discover_notice_board_ids_from_course_page(html: str) -> list[str]:
-    soup = BeautifulSoup(html, "html.parser")
-    found: list[str] = []
-
-    def in_header_like_region(element: Any) -> bool:
-        current = element
-        for _ in range(12):
-            if not current or not getattr(current, "attrs", None):
-                break
-            classes = " ".join(current.attrs.get("class", [])).lower()
-            if any(
-                marker in classes
-                for marker in ("ks-header", "all-menu", "tooltip-layer", "breadcrumb", "navbar", "footer", "menu")
-            ):
-                return True
-            current = current.parent
-        return False
-
-    for anchor in soup.find_all("a", href=True):
-        href = str(anchor["href"])
-        if "mod/courseboard/view.php" not in href:
-            continue
-        match = re.search(r"[?&]id=(\d+)", href)
-        if not match:
-            continue
-        board_id = match.group(1)
-        label = anchor.get_text(" ", strip=True).lower()
-        if anchor.get("target") == "_blank" or in_header_like_region(anchor):
-            continue
-        if board_id in {"32044", "32045", "32047", "531193"}:
-            continue
-        if label in {"notice", "guide to klms", "q&a", "faq"}:
-            continue
-        found.append(board_id)
-    return _dedupe_strings(found)
 
 
 def _extract_surface_links(html: str, *, base_url: str, per_pattern_limit: int) -> list[str]:
@@ -113,19 +77,6 @@ def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     chmod_best_effort(path, 0o600)
 
 
-def _unwrap_moodle_ajax_data(text: str) -> Any | None:
-    try:
-        payload = json.loads(text)
-    except Exception:
-        return None
-    if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
-        return None
-    first = payload[0]
-    if bool(first.get("error")):
-        return None
-    return first.get("data")
-
-
 def _moodle_ajax_state(text: str) -> str:
     try:
         payload = json.loads(text)
@@ -144,18 +95,12 @@ def _moodle_ajax_state(text: str) -> str:
 def _extract_assignment_rows_from_calendar_data(data: Any, *, base_url: str) -> list[dict[str, Any]]:
     candidates: list[dict[str, Any]] = []
 
-    def push_list(items: Any) -> None:
-        if isinstance(items, list):
-            for item in items:
-                if isinstance(item, dict):
-                    candidates.append(item)
-
     if isinstance(data, dict):
-        push_list(data.get("events"))
-        push_list(data.get("data"))
-        push_list(data.get("items"))
+        extend_dict_candidates(candidates, data.get("events"))
+        extend_dict_candidates(candidates, data.get("data"))
+        extend_dict_candidates(candidates, data.get("items"))
     elif isinstance(data, list):
-        push_list(data)
+        extend_dict_candidates(candidates, data)
 
     out: list[dict[str, Any]] = []
     for row in candidates:

--- a/src/kaist_cli/v2/klms/files.py
+++ b/src/kaist_cli/v2/klms/files.py
@@ -5,7 +5,6 @@ import html as _html
 import re
 import sys
 from dataclasses import replace
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -13,6 +12,8 @@ from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
+from ...core.timeutil import cache_is_fresh_enough as _cache_is_fresh_enough, iso_from_epoch_seconds as _iso_from_epoch_seconds
+from .moodle_html import unwrap_moodle_ajax_payload as _unwrap_moodle_ajax_payload
 from .auth import AuthService, looks_logged_out_html, looks_login_url
 from .cache import load_cache_entry, load_cache_value, save_cache_value
 from .config import KlmsConfig, abs_url, load_config
@@ -477,27 +478,6 @@ def _synthesize_file_item_from_url(
     return item
 
 
-def _iso_from_epoch_seconds(value: float | int | None) -> str | None:
-    if not isinstance(value, (int, float)):
-        return None
-    try:
-        return datetime.fromtimestamp(float(value), tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-    except Exception:
-        return None
-
-
-def _cache_is_fresh_enough(entry: dict[str, Any] | None, *, max_age_seconds: int = 3600) -> bool:
-    if not isinstance(entry, dict):
-        return False
-    age_seconds = entry.get("age_seconds")
-    if isinstance(age_seconds, (int, float)):
-        return float(age_seconds) <= float(max_age_seconds)
-    stored_at = entry.get("stored_at")
-    if isinstance(stored_at, (int, float)):
-        return (datetime.now(timezone.utc).timestamp() - float(stored_at)) <= float(max_age_seconds)
-    return False
-
-
 def _provider_warning(code: str, message: str, **extra: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"code": code, "message": message}
     payload.update(extra)
@@ -512,25 +492,6 @@ def _file_provider_source(items: list[FileItem]) -> str:
     if has_api:
         return "api"
     return "html"
-
-
-def _unwrap_moodle_ajax_payload(text: str) -> dict[str, Any]:
-    try:
-        payload = json.loads(text)
-    except Exception as exc:  # noqa: BLE001
-        return {"status": "invalid", "message": f"Failed to parse Moodle AJAX JSON: {exc}"}
-    if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
-        return {"status": "invalid", "message": "Unexpected Moodle AJAX response shape."}
-    first = payload[0]
-    if bool(first.get("error")):
-        exception = first.get("exception") if isinstance(first.get("exception"), dict) else {}
-        return {
-            "status": "error",
-            "error_code": str(exception.get("errorcode") or first.get("errorcode") or "").strip() or None,
-            "message": str(exception.get("message") or first.get("message") or "Moodle AJAX returned an error payload.").strip(),
-            "exception": exception,
-        }
-    return {"status": "ok", "data": first.get("data")}
 
 
 def _extract_file_items_from_course_contents(

--- a/src/kaist_cli/v2/klms/media_recency.py
+++ b/src/kaist_cli/v2/klms/media_recency.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timezone
 from typing import Any
 
 from ...core.state_store import read_json_file, update_json_file
+from ...core.timeutil import utc_now_iso
 from .models import FileItem, Video
 from .paths import KlmsPaths
 
@@ -13,10 +13,6 @@ MEDIA_RECENCY_STORE_VERSION = 1
 
 def _default_store() -> dict[str, Any]:
     return {"version": MEDIA_RECENCY_STORE_VERSION, "files": {}, "videos": {}}
-
-
-def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _bucket(store: dict[str, Any], key: str) -> dict[str, dict[str, Any]]:
@@ -103,7 +99,7 @@ def enrich_videos_with_recency(paths: KlmsPaths, items: list[Video]) -> list[Vid
 
 
 def observe_files(paths: KlmsPaths, items: list[FileItem], *, observed_at: str | None = None) -> list[FileItem]:
-    seen_at = observed_at or _utc_now_iso()
+    seen_at = observed_at or utc_now_iso()
 
     def updater(current: dict[str, Any]) -> dict[str, Any]:
         files = _bucket(current, "files")
@@ -128,7 +124,7 @@ def observe_files(paths: KlmsPaths, items: list[FileItem], *, observed_at: str |
 
 
 def observe_videos(paths: KlmsPaths, items: list[Video], *, observed_at: str | None = None) -> list[Video]:
-    seen_at = observed_at or _utc_now_iso()
+    seen_at = observed_at or utc_now_iso()
 
     def updater(current: dict[str, Any]) -> dict[str, Any]:
         videos = _bucket(current, "videos")

--- a/src/kaist_cli/v2/klms/moodle_html.py
+++ b/src/kaist_cli/v2/klms/moodle_html.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup  # type: ignore[import-untyped]
+
+HEADER_LIKE_MARKERS = (
+    "ks-header",
+    "all-menu",
+    "tooltip-layer",
+    "breadcrumb",
+    "navbar",
+    "footer",
+    "menu",
+)
+
+_SKIP_NOTICE_BOARD_IDS = {"32044", "32045", "32047", "531193"}
+_SKIP_NOTICE_BOARD_LABELS = {"notice", "guide to klms", "q&a", "faq"}
+
+
+def in_header_like_region(element: Any) -> bool:
+    current = element
+    for _ in range(12):
+        if not current or not getattr(current, "attrs", None):
+            break
+        classes = " ".join(current.attrs.get("class", [])).lower()
+        if any(marker in classes for marker in HEADER_LIKE_MARKERS):
+            return True
+        current = current.parent
+    return False
+
+
+def _norm_label(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def discover_notice_board_ids_from_course_page(html: str) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    found: list[str] = []
+    for anchor in soup.find_all("a", href=True):
+        href = str(anchor["href"])
+        if "mod/courseboard/view.php" not in href:
+            continue
+        match = re.search(r"[?&]id=(\d+)", href)
+        if not match:
+            continue
+        board_id = match.group(1)
+        label = _norm_label(anchor.get_text(" ", strip=True))
+        if anchor.get("target") == "_blank" or in_header_like_region(anchor):
+            continue
+        if board_id in _SKIP_NOTICE_BOARD_IDS:
+            continue
+        if label in _SKIP_NOTICE_BOARD_LABELS:
+            continue
+        found.append(board_id)
+    return list(dict.fromkeys(found))
+
+
+def unwrap_moodle_ajax_data(text: str) -> Any | None:
+    payload = unwrap_moodle_ajax_payload(text)
+    if payload.get("status") != "ok":
+        return None
+    return payload.get("data")
+
+
+def unwrap_moodle_ajax_payload(text: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(text)
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "invalid", "message": f"Failed to parse Moodle AJAX JSON: {exc}"}
+    if not isinstance(payload, list) or not payload or not isinstance(payload[0], dict):
+        return {"status": "invalid", "message": "Unexpected Moodle AJAX response shape."}
+    first = payload[0]
+    if bool(first.get("error")):
+        exception = first.get("exception") if isinstance(first.get("exception"), dict) else {}
+        return {
+            "status": "error",
+            "error_code": str(exception.get("errorcode") or first.get("errorcode") or "").strip() or None,
+            "message": str(
+                exception.get("message") or first.get("message") or "Moodle AJAX returned an error payload."
+            ).strip(),
+            "exception": exception,
+        }
+    return {"status": "ok", "data": first.get("data")}
+
+
+def table_col_index(headers_norm: list[str], *needles: str) -> int | None:
+    for needle in needles:
+        for index, header in enumerate(headers_norm):
+            if needle in header:
+                return index
+    return None
+
+
+def extend_dict_candidates(candidates: list[dict[str, Any]], items: Any) -> None:
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict):
+                candidates.append(item)

--- a/src/kaist_cli/v2/klms/notices.py
+++ b/src/kaist_cli/v2/klms/notices.py
@@ -9,6 +9,11 @@ from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
+from ...core.timeutil import cache_is_fresh_enough as _cache_is_fresh_enough, iso_from_epoch_seconds as _iso_from_epoch_seconds
+from .moodle_html import (
+    discover_notice_board_ids_from_course_page as _discover_notice_board_ids_from_course_page,
+    table_col_index,
+)
 from .auth import AuthService, looks_logged_out_html, looks_login_url
 from .cache import list_cache_entries, load_cache_entry, save_cache_value
 from .assignments import _attachment_filename_from_url, _looks_like_attachment_url, _parse_datetime_guess
@@ -132,38 +137,6 @@ def _course_meta_map_for_request(
     }
 
 
-def _discover_notice_board_ids_from_course_page(html: str) -> list[str]:
-    soup = BeautifulSoup(html, "html.parser")
-    found: list[str] = []
-
-    def in_header_like_region(element: Any) -> bool:
-        current = element
-        for _ in range(12):
-            if not current or not getattr(current, "attrs", None):
-                break
-            classes = " ".join(current.attrs.get("class", [])).lower()
-            if any(marker in classes for marker in ("ks-header", "all-menu", "tooltip-layer", "breadcrumb", "navbar", "footer", "menu")):
-                return True
-            current = current.parent
-        return False
-
-    for anchor in soup.find_all("a", href=True):
-        href = str(anchor["href"])
-        if "mod/courseboard/view.php" not in href:
-            continue
-        match = re.search(r"[?&]id=(\d+)", href)
-        if not match:
-            continue
-        board_id = match.group(1)
-        label = _norm_text(anchor.get_text(" ", strip=True)).lower()
-        if anchor.get("target") == "_blank" or in_header_like_region(anchor):
-            continue
-        if board_id in {"32044", "32045", "32047", "531193"}:
-            continue
-        if label in {"notice", "guide to klms", "q&a", "faq"}:
-            continue
-        found.append(board_id)
-    return list(dict.fromkeys(found))
 
 
 def _extract_pagination_pages(soup: BeautifulSoup) -> list[int]:
@@ -235,15 +208,8 @@ def _parse_notice_items_from_soup(
         headers, table = found
         headers_norm = [header.lower() for header in headers]
 
-        def col_index(*needles: str) -> int | None:
-            for needle in needles:
-                for index, header in enumerate(headers_norm):
-                    if needle in header:
-                        return index
-            return None
-
-        title_i = col_index("title", "제목", "subject") or 0
-        date_i = col_index("date", "작성", "등록", "posted", "일자")
+        title_i = table_col_index(headers_norm, "title", "제목", "subject") or 0
+        date_i = table_col_index(headers_norm, "date", "작성", "등록", "posted", "일자")
         rows = table.find_all("tr")
         if rows and rows[0].find_all("th"):
             rows = rows[1:]
@@ -618,27 +584,6 @@ def _collect_notice_attachments(soup: BeautifulSoup, *, base_url: str) -> tuple[
             }
         )
     return tuple(out)
-
-
-def _iso_from_epoch_seconds(value: float | int | None) -> str | None:
-    if not isinstance(value, (int, float)):
-        return None
-    try:
-        return datetime.fromtimestamp(float(value), tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-    except Exception:
-        return None
-
-
-def _cache_is_fresh_enough(entry: dict[str, Any] | None, *, max_age_seconds: int = 3600) -> bool:
-    if not isinstance(entry, dict):
-        return False
-    age_seconds = entry.get("age_seconds")
-    if isinstance(age_seconds, (int, float)):
-        return float(age_seconds) <= float(max_age_seconds)
-    stored_at = entry.get("stored_at")
-    if isinstance(stored_at, (int, float)):
-        return (datetime.now(timezone.utc).timestamp() - float(stored_at)) <= float(max_age_seconds)
-    return False
 
 
 def _finalize_notice_items(items: list[Notice], *, since_iso: str | None, limit: int | None) -> list[Notice]:

--- a/src/kaist_cli/v2/klms/videos.py
+++ b/src/kaist_cli/v2/klms/videos.py
@@ -29,6 +29,7 @@ from .media_recency import observe_videos
 from .paths import KlmsPaths
 from .session import KlmsSessionBootstrap, build_session_bootstrap, fetch_html_batch
 from .validate import looks_klms_error_html
+from .moodle_html import in_header_like_region
 
 MAX_VIDEO_HTTP_WORKERS = 4
 
@@ -106,20 +107,6 @@ def _extract_video_items_from_html(
 ) -> list[Video]:
     soup = BeautifulSoup(html, "html.parser")
     out: list[Video] = []
-
-    def in_header_like_region(element: Any) -> bool:
-        current = element
-        for _ in range(12):
-            if not current or not getattr(current, "attrs", None):
-                break
-            classes = " ".join(current.attrs.get("class", [])).lower()
-            if any(
-                marker in classes
-                for marker in ("ks-header", "all-menu", "tooltip-layer", "breadcrumb", "navbar", "footer", "menu")
-            ):
-                return True
-            current = current.parent
-        return False
 
     for anchor in soup.find_all("a", href=True):
         href = str(anchor.get("href") or "").strip()

--- a/src/kaist_cli/v2/parser.py
+++ b/src/kaist_cli/v2/parser.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import argparse
 from typing import Any, Callable
 
-
-class _HelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
-    pass
+from ..cli.help_format import HelpFormatter as _HelpFormatter
 
 
 Handler = Callable[[argparse.Namespace], Any]

--- a/src/kaist_cli/v2/parser.py
+++ b/src/kaist_cli/v2/parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from typing import Any, Callable
 
-from ..cli.help_format import HelpFormatter as _HelpFormatter
+from ..core.help_format import HelpFormatter as _HelpFormatter
 
 
 Handler = Callable[[argparse.Namespace], Any]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second of six PRs removing AI code slop. **Dedup only** — extract shared helpers with no intentional behavior change (one documented capture alignment below).

### New modules
- [`core/timeutil.py`](src/kaist_cli/core/timeutil.py) — `utc_now_iso`, `iso_from_epoch_seconds`, `cache_is_fresh_enough`
- [`core/fsutil.py`](src/kaist_cli/core/fsutil.py) — `remove_path`
- [`core/help_format.py`](src/kaist_cli/core/help_format.py) — `HelpFormatter`, `dedent` (systems/v2 import from core; thin `cli.help_format` re-export kept)
- [`v2/klms/moodle_html.py`](src/kaist_cli/v2/klms/moodle_html.py) — header filter, notice-board discovery, Moodle AJAX unwrap, table col index, dict-list extend

### Rewired
files/notices/assignments/videos/capture, auth_session, media_recency, envelopes, agents/updater, system adapters, cli/v2 parsers

### Review notes
- Capture notice-board discovery now uses the notices label normalizer (`whitespace collapse + lower`) via the shared helper. Previously capture used plain `.lower()` only — intentional alignment to the stricter notices path.
- Moved help formatting to `core/` so `systems/*` does not depend on `cli`.

### Test plan
- [x] Full `pytest` (251 passed)

Stacked on PR1 (merged to `main`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c401e5bd-d26e-43d7-beda-a79c61428cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c401e5bd-d26e-43d7-beda-a79c61428cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

