### PR TITLE
Factor provider load and dashboard session helpers (PR3/6)

### DIFF
--- a/src/kaist_cli/v2/klms/assignments.py
+++ b/src/kaist_cli/v2/klms/assignments.py
@@ -31,7 +31,7 @@ from .discovery import load_json_summary
 from .file_metadata import normalize_filename
 from .models import Assignment
 from .paths import KlmsPaths
-from .provider_state import ProviderLoad
+from .provider_state import ProviderLoad, live_provider_load_from_result, run_list_authenticated
 from .session import KlmsSessionBootstrap, build_session_bootstrap
 from .validate import looks_klms_error_html
 
@@ -563,26 +563,15 @@ class AssignmentService:
         limit: int | None = None,
         include_past: bool = False,
     ) -> CommandResult:
-        config = load_config(self._paths)
-
-        def callback(context: Any, auth_mode: str) -> CommandResult:
-            return self.list_with_context(
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                course_id=course_id,
-                course_query=course_query,
-                since_iso=since_iso,
-                limit=limit,
-                include_past=include_past,
-            )
-
-        return self._auth.run_authenticated(
-            config=config,
-            headless=True,
-            accept_downloads=False,
-            timeout_seconds=10.0,
-            callback=callback,
+        return run_list_authenticated(
+            self._auth,
+            paths=self._paths,
+            list_with_context=self.list_with_context,
+            course_id=course_id,
+            course_query=course_query,
+            since_iso=since_iso,
+            limit=limit,
+            include_past=include_past,
         )
 
     def load_for_dashboard(
@@ -598,23 +587,9 @@ class AssignmentService:
         deadline: RefreshDeadline | None = None,
     ) -> ProviderLoad:
         if deadline is not None and deadline.hard_expired():
-            return ProviderLoad(
-                items=[],
-                source="moodle_ajax",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=False,
-                ok=False,
-                warnings=(
-                    {
-                        "code": "LIVE_REFRESH_TIMEOUT",
-                        "message": "Interactive refresh budget expired before the assignment refresh started.",
-                    },
-                ),
+            return live_provider_load_from_result(
+                CommandResult(data=[], source="moodle_ajax", capability="degraded"),
+                deadline=deadline,
             )
 
         result = self.list_with_context(
@@ -626,18 +601,10 @@ class AssignmentService:
             limit=limit,
             bootstrap=bootstrap,
         )
-        rows = [row for row in result.data if isinstance(row, dict)] if isinstance(result.data, list) else []
-        return ProviderLoad(
-            items=rows,
-            source=result.source,
-            capability=result.capability,
-            freshness_mode="live",
-            cache_hit=False,
-            stale=False,
+        return live_provider_load_from_result(
+            result,
+            deadline=None,
             fetched_at=_iso_now_utc(),
-            expires_at=None,
-            refresh_attempted=True,
-            ok=True,
         )
 
     def show(self, assignment_id: str, *, course_id_hint: str | None = None) -> CommandResult:

--- a/src/kaist_cli/v2/klms/courses.py
+++ b/src/kaist_cli/v2/klms/courses.py
@@ -244,6 +244,63 @@ def _load_recent_courses_from_bootstrap(
         return []
 
 
+def _course_map_from_dashboard(html: str, *, base_url: str, configured_ids: tuple[str, ...]) -> _CourseMetadataMap:
+    return _course_metadata_map(
+        _select_dashboard_courses(
+            html,
+            base_url=base_url,
+            exclude_patterns=(),
+            course_query=None,
+            include_past=True,
+            allow_termless_fallback=True,
+        ),
+        configured_ids=configured_ids,
+    )
+
+
+def course_map_for_request(
+    paths: KlmsPaths,
+    bootstrap: KlmsSessionBootstrap,
+    *,
+    config: KlmsConfig,
+    course_id: str | None,
+    course_query: str | None = None,
+) -> _CourseMetadataMap:
+    course_map = _course_map_from_dashboard(
+        bootstrap.dashboard_html,
+        base_url=config.base_url,
+        configured_ids=config.course_ids,
+    )
+    course_map = _merge_course_metadata_rows(
+        course_map,
+        _load_recent_courses_from_bootstrap(
+            paths,
+            bootstrap,
+            exclude_patterns=config.exclude_course_title_patterns,
+        ),
+    )
+    if course_id:
+        target = str(course_id).strip()
+        course_meta = course_map.get(target) or _empty_course_metadata_row(target)
+        return {target: course_meta}
+    discovered = _select_dashboard_courses(
+        bootstrap.dashboard_html,
+        base_url=config.base_url,
+        exclude_patterns=config.exclude_course_title_patterns,
+        course_query=None,
+        include_past=False,
+        allow_termless_fallback=True,
+    )
+    selected_ids = {str(course.id).strip() for course in discovered if str(course.id).strip()}
+    return {
+        key: value
+        for key, value in course_map.items()
+        if key in selected_ids
+        and not _is_noise_course(str(value.get("course_title") or ""), config.exclude_course_title_patterns)
+        and _course_matches_query(value, course_query)
+    }
+
+
 def _course_matches_query(course: Course, query: str | None) -> bool:
     needle = _normalize_course_match_value(query)
     if not needle:

--- a/src/kaist_cli/v2/klms/courses.py
+++ b/src/kaist_cli/v2/klms/courses.py
@@ -244,18 +244,27 @@ def _load_recent_courses_from_bootstrap(
         return []
 
 
-def _course_map_from_dashboard(html: str, *, base_url: str, configured_ids: tuple[str, ...]) -> _CourseMetadataMap:
-    return _course_metadata_map(
-        _select_dashboard_courses(
+def _course_map_from_dashboard(
+    html: str,
+    *,
+    base_url: str,
+    configured_ids: tuple[str, ...],
+    include_noise: bool = False,
+) -> _CourseMetadataMap:
+    if include_noise:
+        # Videos historically keep noise courses in the metadata map so an
+        # explicit course_id lookup still gets dashboard title/code.
+        discovered = _discover_courses_from_dashboard(html, base_url=base_url)
+    else:
+        discovered = _select_dashboard_courses(
             html,
             base_url=base_url,
             exclude_patterns=(),
             course_query=None,
             include_past=True,
             allow_termless_fallback=True,
-        ),
-        configured_ids=configured_ids,
-    )
+        )
+    return _course_metadata_map(discovered, configured_ids=configured_ids)
 
 
 def course_map_for_request(
@@ -265,11 +274,13 @@ def course_map_for_request(
     config: KlmsConfig,
     course_id: str | None,
     course_query: str | None = None,
+    include_noise: bool = False,
 ) -> _CourseMetadataMap:
     course_map = _course_map_from_dashboard(
         bootstrap.dashboard_html,
         base_url=config.base_url,
         configured_ids=config.course_ids,
+        include_noise=include_noise,
     )
     course_map = _merge_course_metadata_rows(
         course_map,

--- a/src/kaist_cli/v2/klms/dashboard.py
+++ b/src/kaist_cli/v2/klms/dashboard.py
@@ -371,7 +371,7 @@ class DashboardService:
         def build_result(context: Any, auth_mode: str, bootstrap: Any) -> CommandResult:
             warnings: list[dict[str, Any]] = []
             provider_status: dict[str, Any] = {}
-            loads = self._collect_parallel_loads(
+            loads = self._run_components_parallel(
                 [
                     (
                         "assignments",
@@ -466,7 +466,7 @@ class DashboardService:
         def build_result(context: Any, auth_mode: str, bootstrap: Any) -> CommandResult:
             warnings: list[dict[str, Any]] = []
             provider_status: dict[str, Any] = {}
-            loads = self._collect_parallel_loads(
+            loads = self._run_components_parallel(
                 [
                     (
                         "assignments",
@@ -585,7 +585,7 @@ class DashboardService:
             warnings.extend(assignments_load.provider_warnings("assignments"))
             provider_status["assignments"] = assignments_load.provider_status()
 
-            loads = self._collect_parallel_loads(
+            loads = self._run_components_parallel(
                 [
                     (
                         "notices",
@@ -750,16 +750,6 @@ class DashboardService:
                 ),
             )
         return result
-
-    @classmethod
-    def _collect_parallel_loads(
-        cls,
-        components: list[tuple[str, Callable[[], ProviderLoad]]],
-        *,
-        warnings: list[dict[str, Any]],
-        provider_status: dict[str, Any],
-    ) -> dict[str, ProviderLoad]:
-        return cls._run_components_parallel(components, warnings=warnings, provider_status=provider_status)
 
     @classmethod
     def _run_components_parallel(

--- a/src/kaist_cli/v2/klms/dashboard.py
+++ b/src/kaist_cli/v2/klms/dashboard.py
@@ -368,19 +368,10 @@ class DashboardService:
         deadline = RefreshDeadline.start()
         notice_floor_iso = since_iso or (now - timedelta(days=21)).isoformat(timespec="seconds")
 
-        def callback(context: Any, auth_mode: str, dashboard_state: dict[str, Any]) -> CommandResult:
-            bootstrap = build_session_bootstrap(
-                self._paths,
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                timeout_seconds=10.0,
-                dashboard_url=str(dashboard_state.get("final_url") or ""),
-                dashboard_html=str(dashboard_state.get("html") or ""),
-            )
+        def build_result(context: Any, auth_mode: str, bootstrap: Any) -> CommandResult:
             warnings: list[dict[str, Any]] = []
             provider_status: dict[str, Any] = {}
-            loads = self._run_components_parallel(
+            loads = self._collect_parallel_loads(
                 [
                     (
                         "assignments",
@@ -454,13 +445,7 @@ class DashboardService:
                 capability=_merge_capability(successes, had_warnings=bool(warnings)),
             )
 
-        return self._auth.run_authenticated_with_state(
-            config=config,
-            headless=True,
-            accept_downloads=False,
-            timeout_seconds=deadline.request_timeout(10.0, use_soft=False),
-            callback=callback,
-        )
+        return self._with_dashboard_session(config=config, deadline=deadline, build_result=build_result)
 
     def today(
         self,
@@ -478,19 +463,10 @@ class DashboardService:
         deadline = RefreshDeadline.start()
         notice_floor_iso = (now - timedelta(days=notice_days)).isoformat(timespec="seconds")
 
-        def callback(context: Any, auth_mode: str, dashboard_state: dict[str, Any]) -> CommandResult:
-            bootstrap = build_session_bootstrap(
-                self._paths,
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                timeout_seconds=10.0,
-                dashboard_url=str(dashboard_state.get("final_url") or ""),
-                dashboard_html=str(dashboard_state.get("html") or ""),
-            )
+        def build_result(context: Any, auth_mode: str, bootstrap: Any) -> CommandResult:
             warnings: list[dict[str, Any]] = []
             provider_status: dict[str, Any] = {}
-            loads = self._run_components_parallel(
+            loads = self._collect_parallel_loads(
                 [
                     (
                         "assignments",
@@ -570,13 +546,7 @@ class DashboardService:
                 capability=_merge_capability(successes, had_warnings=bool(warnings)),
             )
 
-        return self._auth.run_authenticated_with_state(
-            config=config,
-            headless=True,
-            accept_downloads=False,
-            timeout_seconds=deadline.request_timeout(10.0, use_soft=False),
-            callback=callback,
-        )
+        return self._with_dashboard_session(config=config, deadline=deadline, build_result=build_result)
 
     def week(
         self,
@@ -594,16 +564,7 @@ class DashboardService:
             hard_seconds=WEEK_COMMAND_HARD_SECONDS,
         )
 
-        def callback(context: Any, auth_mode: str, dashboard_state: dict[str, Any]) -> CommandResult:
-            bootstrap = build_session_bootstrap(
-                self._paths,
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                timeout_seconds=10.0,
-                dashboard_url=str(dashboard_state.get("final_url") or ""),
-                dashboard_html=str(dashboard_state.get("html") or ""),
-            )
+        def build_result(context: Any, auth_mode: str, bootstrap: Any) -> CommandResult:
             warnings: list[dict[str, Any]] = []
             provider_status: dict[str, Any] = {}
             assignments_load = self._run_component(
@@ -624,7 +585,7 @@ class DashboardService:
             warnings.extend(assignments_load.provider_warnings("assignments"))
             provider_status["assignments"] = assignments_load.provider_status()
 
-            loads = self._run_components_parallel(
+            loads = self._collect_parallel_loads(
                 [
                     (
                         "notices",
@@ -710,6 +671,27 @@ class DashboardService:
                 capability=_merge_capability(successes, had_warnings=bool(warnings)),
             )
 
+        return self._with_dashboard_session(config=config, deadline=deadline, build_result=build_result)
+
+    def _with_dashboard_session(
+        self,
+        *,
+        config: Any,
+        deadline: RefreshDeadline,
+        build_result: Callable[[Any, str, Any], CommandResult],
+    ) -> CommandResult:
+        def callback(context: Any, auth_mode: str, dashboard_state: dict[str, Any]) -> CommandResult:
+            bootstrap = build_session_bootstrap(
+                self._paths,
+                context=context,
+                config=config,
+                auth_mode=auth_mode,
+                timeout_seconds=10.0,
+                dashboard_url=str(dashboard_state.get("final_url") or ""),
+                dashboard_html=str(dashboard_state.get("html") or ""),
+            )
+            return build_result(context, auth_mode, bootstrap)
+
         return self._auth.run_authenticated_with_state(
             config=config,
             headless=True,
@@ -768,6 +750,16 @@ class DashboardService:
                 ),
             )
         return result
+
+    @classmethod
+    def _collect_parallel_loads(
+        cls,
+        components: list[tuple[str, Callable[[], ProviderLoad]]],
+        *,
+        warnings: list[dict[str, Any]],
+        provider_status: dict[str, Any],
+    ) -> dict[str, ProviderLoad]:
+        return cls._run_components_parallel(components, warnings=warnings, provider_status=provider_status)
 
     @classmethod
     def _run_components_parallel(

--- a/src/kaist_cli/v2/klms/files.py
+++ b/src/kaist_cli/v2/klms/files.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
-from ...core.timeutil import cache_is_fresh_enough as _cache_is_fresh_enough, iso_from_epoch_seconds as _iso_from_epoch_seconds
+from ...core.timeutil import iso_from_epoch_seconds as _iso_from_epoch_seconds
 from .moodle_html import unwrap_moodle_ajax_payload as _unwrap_moodle_ajax_payload
 from .auth import AuthService, looks_logged_out_html, looks_login_url
 from .cache import load_cache_entry, load_cache_value, save_cache_value
@@ -21,22 +21,17 @@ from .courses import (
     _CourseMetadataMap,
     _CourseMetadataRow,
     _course_code_base,
-    _course_metadata_map,
-    _course_matches_query,
+    course_map_for_request,
     _empty_course_metadata_row,
     _extract_course_code_from_resource_index,
-    _is_noise_course,
-    _load_recent_courses_from_bootstrap,
-    _merge_course_metadata_rows,
     _norm_text,
-    _select_dashboard_courses,
 )
 from .deadline import RefreshDeadline
 from .file_metadata import file_extension, guess_mime_type, normalize_filename
 from .media_recency import enrich_files_with_recency, observe_files
 from .models import FileItem
 from .paths import KlmsPaths
-from .provider_state import ProviderLoad
+from .provider_state import CachedProviderSnapshot, ProviderLoad, load_cached_or_refresh, run_list_authenticated
 from .session import KlmsDownloadFallback, KlmsHttpSession, KlmsSessionBootstrap, build_session_bootstrap, fetch_html_batch
 from .validate import looks_klms_error_html
 
@@ -238,20 +233,6 @@ def _extract_material_title_from_page(html: str) -> str | None:
         if title:
             return title
     return None
-
-
-def _course_map_from_dashboard(html: str, *, base_url: str, configured_ids: tuple[str, ...]) -> _CourseMetadataMap:
-    return _course_metadata_map(
-        _select_dashboard_courses(
-            html,
-            base_url=base_url,
-            exclude_patterns=(),
-            course_query=None,
-            include_past=True,
-            allow_termless_fallback=True,
-        ),
-        configured_ids=configured_ids,
-    )
 
 
 def _build_file_item(
@@ -478,12 +459,6 @@ def _synthesize_file_item_from_url(
     return item
 
 
-def _provider_warning(code: str, message: str, **extra: Any) -> dict[str, Any]:
-    payload: dict[str, Any] = {"code": code, "message": message}
-    payload.update(extra)
-    return payload
-
-
 def _file_provider_source(items: list[FileItem]) -> str:
     has_api = any(str(item.source or "").startswith("api:") for item in items)
     has_html = any(str(item.source or "").startswith("html:") for item in items)
@@ -660,58 +635,8 @@ class FileService:
         cached_items.sort(key=lambda item: (item.course_title or "", item.kind, item.title.lower()))
         cached_limited = cached_items[: max(0, limit)] if limit is not None else cached_items
         cached_source = _file_provider_source(cached_limited)
-        cache_fresh_enough = _cache_is_fresh_enough(cache_entry)
-        if prefer_cache and cache_entry is not None and (not bool(cache_entry.get("stale")) or cache_fresh_enough):
-            return ProviderLoad(
-                items=[item.to_dict() for item in cached_limited],
-                source=cached_source,
-                capability="partial",
-                freshness_mode="cache",
-                cache_hit=True,
-                stale=bool(cache_entry.get("stale")),
-                fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                refresh_attempted=False,
-                ok=True,
-            )
 
-        if deadline is not None and deadline.hard_expired():
-            if cache_entry is not None and cached_limited:
-                warnings: list[dict[str, Any]] = []
-                if not _cache_is_fresh_enough(cache_entry):
-                    warnings.append(_provider_warning("LIVE_REFRESH_TIMEOUT", "Interactive refresh budget expired before file refresh completed."))
-                if bool(cache_entry.get("stale")):
-                    warnings.insert(0, _provider_warning("STALE_CACHE", "Returning stale file cache because live refresh could not finish in time."))
-                return ProviderLoad(
-                    items=[item.to_dict() for item in cached_limited],
-                    source=cached_source,
-                    capability="partial",
-                    freshness_mode="cache",
-                    cache_hit=True,
-                    stale=bool(cache_entry.get("stale")),
-                    fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                    expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                    refresh_attempted=True,
-                    ok=True,
-                    warnings=tuple(warnings),
-                )
-            return ProviderLoad(
-                items=[],
-                source="html",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=False,
-                ok=False,
-                warnings=(
-                    _provider_warning("LIVE_REFRESH_TIMEOUT", "Interactive refresh budget expired before file refresh started."),
-                ),
-            )
-
-        try:
+        def refresh() -> tuple[list[dict[str, Any]], Any, Any]:
             live_items = self._refresh_file_items(
                 config=config,
                 auth_mode=auth_mode,
@@ -720,91 +645,30 @@ class FileService:
                 bootstrap=bootstrap,
                 deadline=deadline,
             )
-        except TimeoutError:
-            if cache_entry is not None and cached_limited:
-                warnings: list[dict[str, Any]] = []
-                if not _cache_is_fresh_enough(cache_entry):
-                    warnings.append(_provider_warning("LIVE_REFRESH_TIMEOUT", "File refresh exceeded the interactive deadline."))
-                if bool(cache_entry.get("stale")):
-                    warnings.insert(0, _provider_warning("STALE_CACHE", "Returning stale file cache because live refresh timed out."))
-                return ProviderLoad(
-                    items=[item.to_dict() for item in cached_limited],
-                    source=cached_source,
-                    capability="partial",
-                    freshness_mode="cache",
-                    cache_hit=True,
-                    stale=bool(cache_entry.get("stale")),
-                    fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                    expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                    refresh_attempted=True,
-                    ok=True,
-                    warnings=tuple(warnings),
-                )
-            return ProviderLoad(
-                items=[],
-                source="html",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=True,
-                ok=False,
-                warnings=(
-                    _provider_warning("LIVE_REFRESH_TIMEOUT", "File refresh exceeded the interactive deadline."),
-                ),
-            )
-        except CommandError:
-            raise
-        except Exception as exc:
-            if cache_entry is not None and cached_limited:
-                warnings: list[dict[str, Any]] = []
-                if not _cache_is_fresh_enough(cache_entry):
-                    warnings.append(_provider_warning("LIVE_REFRESH_FAILED", "File refresh failed; returning cached file data.", error=str(exc)))
-                if bool(cache_entry.get("stale")):
-                    warnings.insert(0, _provider_warning("STALE_CACHE", "Returning stale file cache because live refresh failed."))
-                return ProviderLoad(
-                    items=[item.to_dict() for item in cached_limited],
-                    source=cached_source,
-                    capability="partial",
-                    freshness_mode="cache",
-                    cache_hit=True,
-                    stale=bool(cache_entry.get("stale")),
-                    fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                    expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                    refresh_attempted=True,
-                    ok=True,
-                    warnings=tuple(warnings),
-                )
-            return ProviderLoad(
-                items=[],
-                source="html",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=True,
-                ok=False,
-                warnings=(
-                    _provider_warning("LIVE_REFRESH_FAILED", "File refresh failed.", error=str(exc)),
-                ),
+            return (
+                [item.to_dict() for item in live_items],
+                _file_provider_source(live_items),
+                "partial",
             )
 
-        fresh_entry = load_cache_entry(self._paths, cache_key)
-        return ProviderLoad(
-            items=[item.to_dict() for item in live_items],
-            source=_file_provider_source(live_items),
-            capability="partial",
-            freshness_mode="live",
-            cache_hit=False,
-            stale=False,
-            fetched_at=_iso_from_epoch_seconds((fresh_entry or {}).get("stored_at")),
-            expires_at=_iso_from_epoch_seconds((fresh_entry or {}).get("expires_at")),
-            refresh_attempted=True,
-            ok=True,
+        def fresh_timestamps() -> tuple[str | None, str | None]:
+            fresh_entry = load_cache_entry(self._paths, cache_key)
+            return (
+                _iso_from_epoch_seconds((fresh_entry or {}).get("stored_at")),
+                _iso_from_epoch_seconds((fresh_entry or {}).get("expires_at")),
+            )
+
+        return load_cached_or_refresh(
+            prefer_cache=prefer_cache,
+            deadline=deadline,
+            snapshot=CachedProviderSnapshot(
+                items=[item.to_dict() for item in cached_limited],
+                cache_entry=cache_entry,
+                source=cached_source,  # type: ignore[arg-type]
+            ),
+            refresh=refresh,
+            resource_label="file",
+            fresh_timestamps=fresh_timestamps,
         )
 
     def refresh_cache_with_context(
@@ -828,24 +692,13 @@ class FileService:
         )
 
     def list(self, *, course_id: str | None = None, course_query: str | None = None, limit: int | None = None) -> CommandResult:
-        config = load_config(self._paths)
-
-        def callback(context: Any, auth_mode: str) -> CommandResult:
-            return self.list_with_context(
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                course_id=course_id,
-                course_query=course_query,
-                limit=limit,
-            )
-
-        return self._auth.run_authenticated(
-            config=config,
-            headless=True,
-            accept_downloads=False,
-            timeout_seconds=10.0,
-            callback=callback,
+        return run_list_authenticated(
+            self._auth,
+            paths=self._paths,
+            list_with_context=self.list_with_context,
+            course_id=course_id,
+            course_query=course_query,
+            limit=limit,
         )
 
     def get(self, file_id_or_url: str) -> CommandResult:
@@ -1172,35 +1025,13 @@ class FileService:
         course_id: str | None,
         course_query: str | None = None,
     ) -> _CourseMetadataMap:
-        course_map = _course_map_from_dashboard(bootstrap.dashboard_html, base_url=config.base_url, configured_ids=config.course_ids)
-        course_map = _merge_course_metadata_rows(
-            course_map,
-            _load_recent_courses_from_bootstrap(
-                self._paths,
-                bootstrap,
-                exclude_patterns=config.exclude_course_title_patterns,
-            ),
+        return course_map_for_request(
+            self._paths,
+            bootstrap,
+            config=config,
+            course_id=course_id,
+            course_query=course_query,
         )
-        if course_id:
-            target = str(course_id).strip()
-            course_meta = course_map.get(target) or _empty_course_metadata_row(target)
-            return {target: course_meta}
-        discovered = _select_dashboard_courses(
-            bootstrap.dashboard_html,
-            base_url=config.base_url,
-            exclude_patterns=config.exclude_course_title_patterns,
-            course_query=None,
-            include_past=False,
-            allow_termless_fallback=True,
-        )
-        selected_ids = {str(course.id).strip() for course in discovered if str(course.id).strip()}
-        return {
-            key: value
-            for key, value in course_map.items()
-            if key in selected_ids
-            and not _is_noise_course(str(value.get("course_title") or ""), config.exclude_course_title_patterns)
-            and _course_matches_query(value, course_query)
-        }
 
     def _refresh_file_items(
         self,

--- a/src/kaist_cli/v2/klms/notices.py
+++ b/src/kaist_cli/v2/klms/notices.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
-from ...core.timeutil import cache_is_fresh_enough as _cache_is_fresh_enough, iso_from_epoch_seconds as _iso_from_epoch_seconds
+from ...core.timeutil import iso_from_epoch_seconds as _iso_from_epoch_seconds
 from .moodle_html import (
     discover_notice_board_ids_from_course_page as _discover_notice_board_ids_from_course_page,
     table_col_index,
@@ -34,7 +34,13 @@ from .deadline import RefreshDeadline
 from .file_metadata import file_extension, guess_mime_type
 from .models import Notice
 from .paths import KlmsPaths
-from .provider_state import ProviderLoad
+from .provider_state import (
+    CachedProviderSnapshot,
+    ProviderLoad,
+    load_cached_or_refresh,
+    provider_warning as _provider_warning,
+    run_list_authenticated,
+)
 from .session import KlmsSessionBootstrap, build_session_bootstrap, fetch_html_batch
 from .validate import looks_klms_error_html
 
@@ -604,12 +610,6 @@ def _matching_notice_count(items: list[Notice], *, since_iso: str | None) -> int
     return sum(1 for item in items if item.posted_iso and item.posted_iso >= floor)
 
 
-def _provider_warning(code: str, message: str, **extra: Any) -> dict[str, Any]:
-    payload: dict[str, Any] = {"code": code, "message": message}
-    payload.update(extra)
-    return payload
-
-
 def _notice_detail_target(notice: Notice, *, base_url: str) -> str | None:
     if notice.url:
         return str(notice.url)
@@ -918,58 +918,8 @@ class NoticeService:
         cached_rows = cache_entry.get("value") if isinstance(cache_entry, dict) else None
         cached_items = [Notice(**row) for row in cached_rows if isinstance(row, dict)] if isinstance(cached_rows, list) else []
         cached_filtered = _finalize_notice_items(cached_items, since_iso=since_iso, limit=limit)
-        cache_fresh_enough = _cache_is_fresh_enough(cache_entry)
-        if prefer_cache and cache_entry is not None and (not bool(cache_entry.get("stale")) or cache_fresh_enough):
-            return ProviderLoad(
-                items=[item.to_dict() for item in cached_filtered],
-                source="html",
-                capability="partial",
-                freshness_mode="cache",
-                cache_hit=True,
-                stale=bool(cache_entry.get("stale")),
-                fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                refresh_attempted=False,
-                ok=True,
-            )
 
-        if deadline is not None and deadline.hard_expired():
-            if cache_entry is not None and cached_filtered:
-                warnings: list[dict[str, Any]] = []
-                if not _cache_is_fresh_enough(cache_entry):
-                    warnings.append(_provider_warning("LIVE_REFRESH_TIMEOUT", "Interactive refresh budget expired before notice refresh completed."))
-                if bool(cache_entry.get("stale")):
-                    warnings.insert(0, _provider_warning("STALE_CACHE", "Returning stale notice cache because live refresh could not finish in time."))
-                return ProviderLoad(
-                    items=[item.to_dict() for item in cached_filtered],
-                    source="html",
-                    capability="partial",
-                    freshness_mode="cache",
-                    cache_hit=True,
-                    stale=bool(cache_entry.get("stale")),
-                    fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                    expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                    refresh_attempted=True,
-                    ok=True,
-                    warnings=tuple(warnings),
-                )
-            return ProviderLoad(
-                items=[],
-                source="html",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=False,
-                ok=False,
-                warnings=(
-                    _provider_warning("LIVE_REFRESH_TIMEOUT", "Interactive refresh budget expired before notice refresh started."),
-                ),
-            )
-
-        try:
+        def refresh() -> tuple[list[dict[str, Any]], Any, Any]:
             live_items = self._refresh_notice_items(
                 config=config,
                 auth_mode=auth_mode,
@@ -980,92 +930,27 @@ class NoticeService:
                 bootstrap=bootstrap,
                 deadline=deadline,
             )
-        except TimeoutError:
-            if cache_entry is not None and cached_filtered:
-                warnings: list[dict[str, Any]] = []
-                if not _cache_is_fresh_enough(cache_entry):
-                    warnings.append(_provider_warning("LIVE_REFRESH_TIMEOUT", "Notice refresh exceeded the interactive deadline."))
-                if bool(cache_entry.get("stale")):
-                    warnings.insert(0, _provider_warning("STALE_CACHE", "Returning stale notice cache because live refresh timed out."))
-                return ProviderLoad(
-                    items=[item.to_dict() for item in cached_filtered],
-                    source="html",
-                    capability="partial",
-                    freshness_mode="cache",
-                    cache_hit=True,
-                    stale=bool(cache_entry.get("stale")),
-                    fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                    expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                    refresh_attempted=True,
-                    ok=True,
-                    warnings=tuple(warnings),
-                )
-            return ProviderLoad(
-                items=[],
-                source="html",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=True,
-                ok=False,
-                warnings=(
-                    _provider_warning("LIVE_REFRESH_TIMEOUT", "Notice refresh exceeded the interactive deadline."),
-                ),
-            )
-        except CommandError:
-            raise
-        except Exception as exc:
-            if cache_entry is not None and cached_filtered:
-                warnings: list[dict[str, Any]] = []
-                if not _cache_is_fresh_enough(cache_entry):
-                    warnings.append(_provider_warning("LIVE_REFRESH_FAILED", "Notice refresh failed; returning cached notice data.", error=str(exc)))
-                if bool(cache_entry.get("stale")):
-                    warnings.insert(0, _provider_warning("STALE_CACHE", "Returning stale notice cache because live refresh failed."))
-                return ProviderLoad(
-                    items=[item.to_dict() for item in cached_filtered],
-                    source="html",
-                    capability="partial",
-                    freshness_mode="cache",
-                    cache_hit=True,
-                    stale=bool(cache_entry.get("stale")),
-                    fetched_at=_iso_from_epoch_seconds(cache_entry.get("stored_at")),
-                    expires_at=_iso_from_epoch_seconds(cache_entry.get("expires_at")),
-                    refresh_attempted=True,
-                    ok=True,
-                    warnings=tuple(warnings),
-                )
-            return ProviderLoad(
-                items=[],
-                source="html",
-                capability="degraded",
-                freshness_mode="live",
-                cache_hit=False,
-                stale=False,
-                fetched_at=None,
-                expires_at=None,
-                refresh_attempted=True,
-                ok=False,
-                warnings=(
-                    _provider_warning("LIVE_REFRESH_FAILED", "Notice refresh failed.", error=str(exc)),
-                ),
+            live_filtered = _finalize_notice_items(live_items, since_iso=since_iso, limit=limit)
+            return ([item.to_dict() for item in live_filtered], "html", "partial")
+
+        def fresh_timestamps() -> tuple[str | None, str | None]:
+            fresh_entry = load_cache_entry(self._paths, cache_key)
+            return (
+                _iso_from_epoch_seconds((fresh_entry or {}).get("stored_at")),
+                _iso_from_epoch_seconds((fresh_entry or {}).get("expires_at")),
             )
 
-        live_filtered = _finalize_notice_items(live_items, since_iso=since_iso, limit=limit)
-        fresh_entry = load_cache_entry(self._paths, cache_key)
-        return ProviderLoad(
-            items=[item.to_dict() for item in live_filtered],
-            source="html",
-            capability="partial",
-            freshness_mode="live",
-            cache_hit=False,
-            stale=False,
-            fetched_at=_iso_from_epoch_seconds((fresh_entry or {}).get("stored_at")),
-            expires_at=_iso_from_epoch_seconds((fresh_entry or {}).get("expires_at")),
-            refresh_attempted=True,
-            ok=True,
+        return load_cached_or_refresh(
+            prefer_cache=prefer_cache,
+            deadline=deadline,
+            snapshot=CachedProviderSnapshot(
+                items=[item.to_dict() for item in cached_filtered],
+                cache_entry=cache_entry,
+                source="html",
+            ),
+            refresh=refresh,
+            resource_label="notice",
+            fresh_timestamps=fresh_timestamps,
         )
 
     def refresh_cache_with_context(
@@ -1099,28 +984,17 @@ class NoticeService:
         since_iso: str | None = None,
         limit: int | None = None,
     ) -> CommandResult:
-        config = load_config(self._paths)
         max_pages = max(1, min(max_pages, 10))
-
-        def callback(context: Any, auth_mode: str) -> CommandResult:
-            return self.list_with_context(
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                notice_board_id=notice_board_id,
-                course_id=course_id,
-                course_query=course_query,
-                max_pages=max_pages,
-                since_iso=since_iso,
-                limit=limit,
-            )
-
-        return self._auth.run_authenticated(
-            config=config,
-            headless=True,
-            accept_downloads=False,
-            timeout_seconds=10.0,
-            callback=callback,
+        return run_list_authenticated(
+            self._auth,
+            paths=self._paths,
+            list_with_context=self.list_with_context,
+            notice_board_id=notice_board_id,
+            course_id=course_id,
+            course_query=course_query,
+            max_pages=max_pages,
+            since_iso=since_iso,
+            limit=limit,
         )
 
     def show(

--- a/src/kaist_cli/v2/klms/provider_state.py
+++ b/src/kaist_cli/v2/klms/provider_state.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from ..contracts import Capability, CommandResult, Source
+from ...core.timeutil import cache_is_fresh_enough, iso_from_epoch_seconds, utc_now_iso
+from ..contracts import Capability, CommandError, CommandResult, Source
+from .deadline import RefreshDeadline
 
 
 @dataclass(frozen=True)
@@ -59,3 +62,250 @@ class ProviderLoad:
             }
             for warning in self.warnings
         ]
+
+
+def provider_warning(code: str, message: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"code": code, "message": message}
+    payload.update(extra)
+    return payload
+
+
+@dataclass(frozen=True)
+class CachedProviderSnapshot:
+    items: list[dict[str, Any]]  # already to_dict'd and limited/filtered
+    cache_entry: dict[str, Any] | None
+    source: Source
+    capability: Capability = "partial"
+    empty_fail_source: Source = "html"
+
+
+def _resource_title(resource_label: str) -> str:
+    return str(resource_label).strip().capitalize()
+
+
+def load_cached_or_refresh(
+    *,
+    prefer_cache: bool,
+    deadline: RefreshDeadline | None,
+    snapshot: CachedProviderSnapshot,
+    refresh: Callable[[], tuple[list[dict[str, Any]], Source, Capability]],
+    resource_label: str,  # "file" or "notice"
+    fresh_timestamps: Callable[[], tuple[str | None, str | None]] | None = None,
+) -> ProviderLoad:
+    cache_entry = snapshot.cache_entry
+    cached_items = snapshot.items
+    cache_fresh_enough = cache_is_fresh_enough(cache_entry)
+    resource = str(resource_label).strip() or "item"
+    resource_title = _resource_title(resource)
+
+    def _cached_load(*, refresh_attempted: bool, warnings: list[dict[str, Any]]) -> ProviderLoad:
+        assert cache_entry is not None
+        return ProviderLoad(
+            items=list(cached_items),
+            source=snapshot.source,
+            capability=snapshot.capability,
+            freshness_mode="cache",
+            cache_hit=True,
+            stale=bool(cache_entry.get("stale")),
+            fetched_at=iso_from_epoch_seconds(cache_entry.get("stored_at")),
+            expires_at=iso_from_epoch_seconds(cache_entry.get("expires_at")),
+            refresh_attempted=refresh_attempted,
+            ok=True,
+            warnings=tuple(warnings),
+        )
+
+    def _empty_fail(*, refresh_attempted: bool, warnings: tuple[dict[str, Any], ...]) -> ProviderLoad:
+        return ProviderLoad(
+            items=[],
+            source=snapshot.empty_fail_source,
+            capability="degraded",
+            freshness_mode="live",
+            cache_hit=False,
+            stale=False,
+            fetched_at=None,
+            expires_at=None,
+            refresh_attempted=refresh_attempted,
+            ok=False,
+            warnings=warnings,
+        )
+
+    if prefer_cache and cache_entry is not None and (not bool(cache_entry.get("stale")) or cache_fresh_enough):
+        return _cached_load(refresh_attempted=False, warnings=[])
+
+    if deadline is not None and deadline.hard_expired():
+        if cache_entry is not None and cached_items:
+            warnings: list[dict[str, Any]] = []
+            if not cache_is_fresh_enough(cache_entry):
+                warnings.append(
+                    provider_warning(
+                        "LIVE_REFRESH_TIMEOUT",
+                        f"Interactive refresh budget expired before {resource} refresh completed.",
+                    )
+                )
+            if bool(cache_entry.get("stale")):
+                warnings.insert(
+                    0,
+                    provider_warning(
+                        "STALE_CACHE",
+                        f"Returning stale {resource} cache because live refresh could not finish in time.",
+                    ),
+                )
+            return _cached_load(refresh_attempted=True, warnings=warnings)
+        return _empty_fail(
+            refresh_attempted=False,
+            warnings=(
+                provider_warning(
+                    "LIVE_REFRESH_TIMEOUT",
+                    f"Interactive refresh budget expired before {resource} refresh started.",
+                ),
+            ),
+        )
+
+    try:
+        live_items, live_source, live_capability = refresh()
+    except TimeoutError:
+        if cache_entry is not None and cached_items:
+            warnings = []
+            if not cache_is_fresh_enough(cache_entry):
+                warnings.append(
+                    provider_warning(
+                        "LIVE_REFRESH_TIMEOUT",
+                        f"{resource_title} refresh exceeded the interactive deadline.",
+                    )
+                )
+            if bool(cache_entry.get("stale")):
+                warnings.insert(
+                    0,
+                    provider_warning(
+                        "STALE_CACHE",
+                        f"Returning stale {resource} cache because live refresh timed out.",
+                    ),
+                )
+            return _cached_load(refresh_attempted=True, warnings=warnings)
+        return _empty_fail(
+            refresh_attempted=True,
+            warnings=(
+                provider_warning(
+                    "LIVE_REFRESH_TIMEOUT",
+                    f"{resource_title} refresh exceeded the interactive deadline.",
+                ),
+            ),
+        )
+    except CommandError:
+        raise
+    except Exception as exc:
+        if cache_entry is not None and cached_items:
+            warnings = []
+            if not cache_is_fresh_enough(cache_entry):
+                warnings.append(
+                    provider_warning(
+                        "LIVE_REFRESH_FAILED",
+                        f"{resource_title} refresh failed; returning cached {resource} data.",
+                        error=str(exc),
+                    )
+                )
+            if bool(cache_entry.get("stale")):
+                warnings.insert(
+                    0,
+                    provider_warning(
+                        "STALE_CACHE",
+                        f"Returning stale {resource} cache because live refresh failed.",
+                    ),
+                )
+            return _cached_load(refresh_attempted=True, warnings=warnings)
+        return _empty_fail(
+            refresh_attempted=True,
+            warnings=(
+                provider_warning(
+                    "LIVE_REFRESH_FAILED",
+                    f"{resource_title} refresh failed.",
+                    error=str(exc),
+                ),
+            ),
+        )
+
+    fetched_at: str | None = None
+    expires_at: str | None = None
+    if fresh_timestamps is not None:
+        fetched_at, expires_at = fresh_timestamps()
+    return ProviderLoad(
+        items=list(live_items),
+        source=live_source,
+        capability=live_capability,
+        freshness_mode="live",
+        cache_hit=False,
+        stale=False,
+        fetched_at=fetched_at,
+        expires_at=expires_at,
+        refresh_attempted=True,
+        ok=True,
+    )
+
+
+def run_list_authenticated(
+    auth: Any,  # AuthService
+    *,
+    paths: Any,  # KlmsPaths
+    list_with_context: Callable[..., CommandResult],
+    timeout_seconds: float = 10.0,
+    **list_kwargs: Any,
+) -> CommandResult:
+    from .config import load_config
+
+    config = load_config(paths)
+
+    def callback(context: Any, auth_mode: str) -> CommandResult:
+        return list_with_context(
+            context=context,
+            config=config,
+            auth_mode=auth_mode,
+            **list_kwargs,
+        )
+
+    return auth.run_authenticated(
+        config=config,
+        headless=True,
+        accept_downloads=False,
+        timeout_seconds=timeout_seconds,
+        callback=callback,
+    )
+
+
+def live_provider_load_from_result(
+    result: CommandResult,
+    *,
+    deadline: RefreshDeadline | None,
+    timeout_message: str = "Interactive refresh budget expired before the assignment refresh started.",
+    empty_source: Source = "moodle_ajax",
+    fetched_at: str | None = None,
+) -> ProviderLoad:
+    if deadline is not None and deadline.hard_expired():
+        return ProviderLoad(
+            items=[],
+            source=empty_source,
+            capability="degraded",
+            freshness_mode="live",
+            cache_hit=False,
+            stale=False,
+            fetched_at=None,
+            expires_at=None,
+            refresh_attempted=False,
+            ok=False,
+            warnings=(
+                provider_warning("LIVE_REFRESH_TIMEOUT", timeout_message),
+            ),
+        )
+
+    rows = [row for row in result.data if isinstance(row, dict)] if isinstance(result.data, list) else []
+    return ProviderLoad(
+        items=rows,
+        source=result.source,
+        capability=result.capability,
+        freshness_mode="live",
+        cache_hit=False,
+        stale=False,
+        fetched_at=fetched_at if fetched_at is not None else utc_now_iso(),
+        expires_at=None,
+        refresh_attempted=True,
+        ok=True,
+    )

--- a/src/kaist_cli/v2/klms/videos.py
+++ b/src/kaist_cli/v2/klms/videos.py
@@ -14,19 +14,13 @@ from .courses import (
     _CourseMetadataMap,
     _CourseMetadataRow,
     _course_code_base,
-    _course_metadata_map,
-    _course_matches_query,
-    _empty_course_metadata_row,
-    _discover_courses_from_dashboard,
-    _is_noise_course,
-    _load_recent_courses_from_bootstrap,
-    _merge_course_metadata_rows,
+    course_map_for_request,
     _norm_text,
-    _select_dashboard_courses,
 )
 from .models import Video
 from .media_recency import observe_videos
 from .paths import KlmsPaths
+from .provider_state import run_list_authenticated
 from .session import KlmsSessionBootstrap, build_session_bootstrap, fetch_html_batch
 from .validate import looks_klms_error_html
 from .moodle_html import in_header_like_region
@@ -55,13 +49,6 @@ def _simplify_video_title(text: str) -> str:
         if head.strip() and tail.strip():
             return tail.strip()
     return title
-
-
-def _course_map_from_dashboard(html: str, *, base_url: str, configured_ids: tuple[str, ...]) -> _CourseMetadataMap:
-    return _course_metadata_map(
-        _discover_courses_from_dashboard(html, base_url=base_url),
-        configured_ids=configured_ids,
-    )
 
 
 def _merge_videos(items: list[Video]) -> list[Video]:
@@ -241,25 +228,14 @@ class VideoService:
         limit: int | None = None,
         recent: bool = False,
     ) -> CommandResult:
-        config = load_config(self._paths)
-
-        def callback(context: Any, auth_mode: str) -> CommandResult:
-            return self.list_with_context(
-                context=context,
-                config=config,
-                auth_mode=auth_mode,
-                course_id=course_id,
-                course_query=course_query,
-                limit=limit,
-                recent=recent,
-            )
-
-        return self._auth.run_authenticated(
-            config=config,
-            headless=True,
-            accept_downloads=False,
-            timeout_seconds=10.0,
-            callback=callback,
+        return run_list_authenticated(
+            self._auth,
+            paths=self._paths,
+            list_with_context=self.list_with_context,
+            course_id=course_id,
+            course_query=course_query,
+            limit=limit,
+            recent=recent,
         )
 
     def show(self, video_id_or_url: str, *, course_id_hint: str | None = None) -> CommandResult:
@@ -411,35 +387,13 @@ class VideoService:
         course_id: str | None,
         course_query: str | None = None,
     ) -> _CourseMetadataMap:
-        course_map = _course_map_from_dashboard(bootstrap.dashboard_html, base_url=config.base_url, configured_ids=config.course_ids)
-        course_map = _merge_course_metadata_rows(
-            course_map,
-            _load_recent_courses_from_bootstrap(
-                self._paths,
-                bootstrap,
-                exclude_patterns=config.exclude_course_title_patterns,
-            ),
+        return course_map_for_request(
+            self._paths,
+            bootstrap,
+            config=config,
+            course_id=course_id,
+            course_query=course_query,
         )
-        if course_id:
-            target = str(course_id).strip()
-            course_meta = course_map.get(target) or _empty_course_metadata_row(target)
-            return {target: course_meta}
-        discovered = _select_dashboard_courses(
-            bootstrap.dashboard_html,
-            base_url=config.base_url,
-            exclude_patterns=config.exclude_course_title_patterns,
-            course_query=None,
-            include_past=False,
-            allow_termless_fallback=True,
-        )
-        selected_ids = {str(course.id).strip() for course in discovered if str(course.id).strip()}
-        return {
-            key: value
-            for key, value in course_map.items()
-            if key in selected_ids
-            if not _is_noise_course(str(value.get("course_title") or ""), config.exclude_course_title_patterns)
-            and _course_matches_query(value, course_query)
-        }
 
     def _resolve_target_video(
         self,

--- a/src/kaist_cli/v2/klms/videos.py
+++ b/src/kaist_cli/v2/klms/videos.py
@@ -393,6 +393,7 @@ class VideoService:
             config=config,
             course_id=course_id,
             course_query=course_query,
+            include_noise=True,
         )
 
     def _resolve_target_video(

--- a/tests/test_v2_cli.py
+++ b/tests/test_v2_cli.py
@@ -3380,7 +3380,7 @@ def test_file_course_map_matches_recent_course_alias_variant(tmp_path: Path, mon
             """
         )
         monkeypatch.setattr(
-            "kaist_cli.v2.klms.files._load_recent_courses_from_bootstrap",
+            "kaist_cli.v2.klms.courses._load_recent_courses_from_bootstrap",
             lambda *args, **kwargs: [
                 Course(
                     id="178434",
@@ -3426,7 +3426,7 @@ def test_video_course_map_matches_recent_course_alias_variant(tmp_path: Path, mo
             """
         )
         monkeypatch.setattr(
-            "kaist_cli.v2.klms.videos._load_recent_courses_from_bootstrap",
+            "kaist_cli.v2.klms.courses._load_recent_courses_from_bootstrap",
             lambda *args, **kwargs: [
                 Course(
                     id="178434",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third of six PRs removing AI code slop. Replaces structural clones with shared provider/dashboard helpers.

### Changes
- [`provider_state.py`](src/kaist_cli/v2/klms/provider_state.py): `load_cached_or_refresh`, `run_list_authenticated`, `live_provider_load_from_result`, `provider_warning`
- Files/notices `load_for_dashboard` use the shared cache/deadline matrix
- All four resource `list()` methods use `run_list_authenticated`
- [`courses.course_map_for_request`](src/kaist_cli/v2/klms/courses.py) shared by files/videos (`include_noise=True` preserves videos’ prior metadata-map behavior)
- Dashboard `_with_dashboard_session` for inbox/today/week auth+bootstrap shell

### Review notes
- Restored videos course-map `include_noise` so explicit noise-course id lookups still get dashboard metadata
- Removed no-op `_collect_parallel_loads` alias
- PR #21 recent-courses soft-fail preserved

### Test plan
- [x] Full `pytest` (251 passed)

Stacked on PR2 (merged to `main`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c401e5bd-d26e-43d7-beda-a79c61428cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c401e5bd-d26e-43d7-beda-a79c61428cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

