### PR TITLE
Review fixes for CLI perf PR (#27)

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,13 +37,13 @@ Investigation notes for where `kaist` spends wall time, why, and what we optimiz
 - Honor `KAIST_KLMS_CONCURRENCY` in `fetch_html_batch` and course-batch loops.
 - Keep an in-process cache snapshot so parallel providers do not re-read `cache.json` on every lookup; write compact JSON.
 - Upgrade shared `run_list_authenticated` to pass auth dashboard state into list commands so bootstrap skips a second dashboard GET.
-- Parallelize assignment HTML fallback across courses.
-- Parallelize `sync run` notice and file refreshes.
-- Allow standalone notice/file lists to reuse soft-stale cache within ~1 hour via shared `cache_is_fresh_enough`.
+- Parallelize assignment HTML fallback across courses. HTTP fan-out stays parallel; Playwright browser fallback runs serially on the caller thread when a path fails or returns a login page.
 
 ## Intentionally not changed
 
 - `week` still runs assignments first under a dedicated budget, then notices/files in parallel. Parallelizing all three can starve notice/file work inside the week envelope.
+- `sync run` keeps notice then file refresh serial. Parallelizing them would share one Playwright context across threads when either provider falls back to browser pages.
+- Standalone `notices list` / `files list` still require hard-fresh cache. Soft-stale reuse (`cache_is_fresh_enough`, ~1 hour) stays limited to dashboard `prefer_cache` paths so explicit list commands do not quietly return expired data.
 
 ## Still open (higher leverage, larger change)
 

--- a/src/kaist_cli/v2/klms/assignments.py
+++ b/src/kaist_cli/v2/klms/assignments.py
@@ -829,6 +829,7 @@ class AssignmentService:
                 bootstrap.http,
                 list(path_by_course.values()),
                 max_workers=MAX_ASSIGNMENT_HTTP_WORKERS,
+                context=context,
             )
             for course, path in path_by_course.items():
                 response = responses.get(path)

--- a/src/kaist_cli/v2/klms/files.py
+++ b/src/kaist_cli/v2/klms/files.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup, Tag  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
-from ...core.timeutil import cache_is_fresh_enough, iso_from_epoch_seconds as _iso_from_epoch_seconds
+from ...core.timeutil import iso_from_epoch_seconds as _iso_from_epoch_seconds
 from .moodle_html import unwrap_moodle_ajax_payload as _unwrap_moodle_ajax_payload
 from .auth import AuthService, looks_logged_out_html, looks_login_url
 from .cache import load_cache_entry, load_cache_value, save_cache_value
@@ -995,11 +995,10 @@ class FileService:
             return []
 
         cache_key = self._file_list_cache_key(config, list(course_map.keys()))
-        cache_entry = load_cache_entry(self._paths, cache_key)
-        cached_rows = cache_entry.get("value") if isinstance(cache_entry, dict) else None
-        if isinstance(cached_rows, list) and (
-            not bool(cache_entry.get("stale")) or cache_is_fresh_enough(cache_entry)
-        ):
+        # Standalone `files list` only reuses hard-fresh cache. Soft-stale reuse is
+        # reserved for dashboard prefer_cache paths via load_cached_or_refresh.
+        cached_rows = load_cache_value(self._paths, cache_key)
+        if isinstance(cached_rows, list):
             cached_items = enrich_files_with_recency(
                 self._paths,
                 [_normalize_file_item_metadata(FileItem(**row)) for row in cached_rows if isinstance(row, dict)],

--- a/src/kaist_cli/v2/klms/notices.py
+++ b/src/kaist_cli/v2/klms/notices.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlparse
 from bs4 import BeautifulSoup, Tag  # type: ignore[import-untyped]
 
 from ..contracts import CommandError, CommandResult
-from ...core.timeutil import cache_is_fresh_enough, iso_from_epoch_seconds as _iso_from_epoch_seconds
+from ...core.timeutil import iso_from_epoch_seconds as _iso_from_epoch_seconds
 from .moodle_html import (
     discover_notice_board_ids_from_course_page as _discover_notice_board_ids_from_course_page,
     table_col_index,
@@ -1355,10 +1355,10 @@ class NoticeService:
             )
 
         cache_entry = self._load_notice_cache_entry(config=config, board_ids=board_ids, max_pages=max_pages)
-        cached_rows = cache_entry.get("value") if isinstance(cache_entry, dict) else None
-        if isinstance(cached_rows, list) and (
-            not bool(cache_entry.get("stale")) or cache_is_fresh_enough(cache_entry)
-        ):
+        # Standalone `notices list` only reuses hard-fresh cache. Soft-stale reuse is
+        # reserved for dashboard prefer_cache paths via load_cached_or_refresh.
+        cached_rows = cache_entry.get("value") if isinstance(cache_entry, dict) and not bool(cache_entry.get("stale")) else None
+        if isinstance(cached_rows, list):
             cached_items = [Notice(**row) for row in cached_rows if isinstance(row, dict)]
             return _finalize_notice_items(cached_items, since_iso=since_iso, limit=limit)
 

--- a/src/kaist_cli/v2/klms/session.py
+++ b/src/kaist_cli/v2/klms/session.py
@@ -268,6 +268,7 @@ def fetch_html_batch(
     *,
     deadline: RefreshDeadline | None = None,
     max_workers: int | None = None,
+    context: BrowserContextLike | None = None,
 ) -> dict[str, KlmsHttpResponse]:
     ordered = [str(path).strip() for path in paths if str(path).strip()]
     if not ordered:
@@ -277,9 +278,12 @@ def fetch_html_batch(
 
     def worker(path: str) -> KlmsHttpResponse:
         timeout_seconds = deadline.request_timeout(20.0, use_soft=False) if deadline is not None else 20.0
+        # HTTP-only in the pool: Playwright fallback must stay on the caller thread.
         return http.get_html(path, timeout_seconds=timeout_seconds)
 
     results: dict[str, KlmsHttpResponse] = {}
+    failed_paths: list[str] = []
+    first_error: Exception | None = None
     executor = ThreadPoolExecutor(max_workers=max(1, min(int(workers), len(ordered))))
     timed_out = False
     try:
@@ -288,7 +292,12 @@ def fetch_html_batch(
         done, not_done = wait(set(futures.keys()), timeout=timeout_seconds)
         for future in done:
             path = futures[future]
-            results[path] = future.result()
+            try:
+                results[path] = future.result()
+            except Exception as exc:
+                failed_paths.append(path)
+                if first_error is None:
+                    first_error = exc
         if not_done:
             timed_out = True
             for future in not_done:
@@ -296,6 +305,19 @@ def fetch_html_batch(
             raise TimeoutError("Interactive refresh budget expired while waiting for batched HTTP fetches.")
     finally:
         executor.shutdown(wait=not timed_out, cancel_futures=timed_out)
+
+    if context is not None:
+        retry_paths = list(dict.fromkeys(failed_paths))
+        for path, response in list(results.items()):
+            if looks_login_url(response.url) or looks_logged_out_html(response.text):
+                if path not in retry_paths:
+                    retry_paths.append(path)
+        for path in retry_paths:
+            timeout_seconds = deadline.request_timeout(20.0, use_soft=False) if deadline is not None else 20.0
+            results[path] = http.get_html(path, context=context, timeout_seconds=timeout_seconds)
+    elif first_error is not None:
+        raise first_error
+
     return results
 
 

--- a/src/kaist_cli/v2/klms/sync.py
+++ b/src/kaist_cli/v2/klms/sync.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Any
 
@@ -12,7 +11,6 @@ from .config import load_config
 from .files import FileService
 from .notices import NoticeService
 from .paths import KlmsPaths
-from .provider_state import ProviderLoad
 from .session import build_session_bootstrap
 from .browser_types import BrowserContextLike
 
@@ -150,41 +148,25 @@ class SyncService:
                 dashboard_url=str(dashboard_state.get("final_url") or ""),
                 dashboard_html=str(dashboard_state.get("html") or ""),
             )
-            notices_duration_ms = 0
-            files_duration_ms = 0
-
-            def refresh_notices() -> ProviderLoad:
-                nonlocal notices_duration_ms
-                started = time.perf_counter()
-                try:
-                    return self._notices.refresh_cache_with_context(
-                        context=context,
-                        config=config,
-                        auth_mode=auth_mode,
-                        max_pages=1,
-                        bootstrap=bootstrap,
-                    )
-                finally:
-                    notices_duration_ms = int((time.perf_counter() - started) * 1000)
-
-            def refresh_files() -> ProviderLoad:
-                nonlocal files_duration_ms
-                started = time.perf_counter()
-                try:
-                    return self._files.refresh_cache_with_context(
-                        context=context,
-                        config=config,
-                        auth_mode=auth_mode,
-                        bootstrap=bootstrap,
-                    )
-                finally:
-                    files_duration_ms = int((time.perf_counter() - started) * 1000)
-
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                notice_future = executor.submit(refresh_notices)
-                files_future = executor.submit(refresh_files)
-                notices = notice_future.result()
-                files = files_future.result()
+            # Keep notice/file refresh serial: both may fall back to Playwright
+            # pages on the shared browser context, which is not thread-safe.
+            notices_started = time.perf_counter()
+            notices = self._notices.refresh_cache_with_context(
+                context=context,
+                config=config,
+                auth_mode=auth_mode,
+                max_pages=1,
+                bootstrap=bootstrap,
+            )
+            notices_duration_ms = int((time.perf_counter() - notices_started) * 1000)
+            files_started = time.perf_counter()
+            files = self._files.refresh_cache_with_context(
+                context=context,
+                config=config,
+                auth_mode=auth_mode,
+                bootstrap=bootstrap,
+            )
+            files_duration_ms = int((time.perf_counter() - files_started) * 1000)
             warnings = notices.provider_warnings("notices") + files.provider_warnings("files")
             payload = _status_from_entries(list_cache_entries(self._paths, prefixes=SYNC_CACHE_PREFIXES))
             payload["providers"]["notices"] = _provider_summary("notices", notices.provider_status(), duration_ms=notices_duration_ms)

--- a/tests/test_perf_helpers.py
+++ b/tests/test_perf_helpers.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from kaist_cli.v2.klms.cache import load_cache_entry, save_cache_value
 from kaist_cli.v2.klms.paths import resolve_paths
-from kaist_cli.v2.klms.session import KlmsHttpSession, http_max_workers
+from kaist_cli.v2.klms.session import KlmsHttpResponse, KlmsHttpSession, fetch_html_batch, http_max_workers
 
 
 def test_http_max_workers_defaults_and_env(monkeypatch) -> None:
@@ -81,3 +84,49 @@ def test_http_session_reuses_thread_local_opener() -> None:
     assert first is second
     rebuilt = session._build_opener()
     assert rebuilt is not first
+
+
+def test_fetch_html_batch_retries_failed_paths_with_browser_context(monkeypatch) -> None:
+    session = KlmsHttpSession(_FakeContext(), base_url="https://klms.kaist.ac.kr")
+    context = _FakeContext()
+    calls: list[tuple[str, bool]] = []
+
+    def fake_get_html(
+        url_or_path: str,
+        *,
+        context: Any | None = None,
+        timeout_seconds: float = 20.0,  # noqa: ARG001
+    ) -> KlmsHttpResponse:
+        calls.append((url_or_path, context is not None))
+        if context is None and url_or_path.endswith("id=2"):
+            raise TimeoutError("http boom")
+        via = "browser" if context is not None else "http"
+        return KlmsHttpResponse(url=f"https://klms.kaist.ac.kr{url_or_path}", text=f"ok:{url_or_path}", via=via)
+
+    monkeypatch.setattr(session, "get_html", fake_get_html)
+    results = fetch_html_batch(
+        session,
+        ["/mod/assign/index.php?id=1", "/mod/assign/index.php?id=2"],
+        max_workers=2,
+        context=context,
+    )
+    assert set(results) == {"/mod/assign/index.php?id=1", "/mod/assign/index.php?id=2"}
+    assert results["/mod/assign/index.php?id=2"].via == "browser"
+    assert ("/mod/assign/index.php?id=2", False) in calls
+    assert ("/mod/assign/index.php?id=2", True) in calls
+
+
+def test_fetch_html_batch_without_context_still_raises_on_http_failure(monkeypatch) -> None:
+    session = KlmsHttpSession(_FakeContext(), base_url="https://klms.kaist.ac.kr")
+
+    def fake_get_html(
+        url_or_path: str,
+        *,
+        context: Any | None = None,  # noqa: ARG001
+        timeout_seconds: float = 20.0,  # noqa: ARG001
+    ) -> KlmsHttpResponse:
+        raise RuntimeError(f"http boom:{url_or_path}")
+
+    monkeypatch.setattr(session, "get_html", fake_get_html)
+    with pytest.raises(RuntimeError, match="http boom"):
+        fetch_html_batch(session, ["/mod/assign/index.php?id=1"], max_workers=1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #27 addressing the review findings that were surprising / risky:

1. **Standalone `notices list` / `files list` soft-stale** — reverted. Explicit list commands only reuse hard-fresh cache again. Soft-stale (`cache_is_fresh_enough`, ~1h) stays limited to dashboard `prefer_cache` paths.
2. **`sync run` parallel notice/file refresh** — reverted to serial. Parallel refresh shared one Playwright context across threads when either provider fell back to `new_page()`.
3. **Assignment HTML batching lost browser fallback** — fixed. `fetch_html_batch` now accepts optional `context`; parallel workers stay HTTP-only, then failed/login paths retry serially with Playwright on the caller thread. Assignments pass `context=`.

## Test plan

- [x] `pytest -q tests/test_perf_helpers.py tests/test_assignments_cli.py tests/test_notices_cli.py tests/test_files_cli.py tests/test_sync_dev_cli.py` (73 passed)
- [x] New coverage for batch retry-with-context and fail-fast without context

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9375-3486-739b-a5a4-33634bac08ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9375-3486-739b-a5a4-33634bac08ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

